### PR TITLE
Add support for HTML `data-` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# purescript-elmish-html
+
+## 0.1.0 — February 14, 2020
+
+- Add support for HTML `data-` attributes via special `_data :: Object String`
+  `props` on all HTML components.
+
+## 0.0.3 – May 23, 2019
+
+- Add CircleCI configuration.
+- Add Spago configuration.
+
+## 0.0.2 – May 23, 2019
+
+- Add `README.md`.
+
+## 0.0.1 – May 9, 2019
+
+- Initial release.

--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-elmish": "^0.1.1"
+    "purescript-elmish": "^0.1.1",
+    "purescript-foreign-object": "^2.0.3"
   }
 }

--- a/codegen/index.js
+++ b/codegen/index.js
@@ -59,6 +59,9 @@ import Elmish.React.Import
   , ImportedReactComponentConstructorWithContent
   )
 
+import Foreign.Object (Object)
+
+
 `
 
 const propType = (e, p) => {
@@ -76,7 +79,8 @@ const propType = (e, p) => {
 const printRow = (e, elProps) =>
   elProps.length > 0
     ? `
-  ( ${elProps.map(p => `${p} :: ${propType(e, p)}`).join("\n  , ")}
+  ( _data :: Object String
+  , ${elProps.map(p => `${p} :: ${propType(e, p)}`).join("\n  , ")}
   | r
   )`
     : "( | r )"

--- a/elmish-html.dhall
+++ b/elmish-html.dhall
@@ -11,7 +11,7 @@ For example:
           https://raw.githubusercontent.com/collegevine/purescript-elmish-html/master/elmish-html.dhall
 
     let additions = {
-      elmish-html = elmish-html "v0.0.2"
+      elmish-html = elmish-html "v0.1.0"
     }
 
     in  upstream // additions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,19 @@
 {
   "name": "purescript-elmish-html",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "dev": true,
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -22,10 +32,10 @@
       "integrity": "sha512-XhahLSsCB6X6CJbe+uNu3Mn9sJBNFxtBN9NLgAOQovfS6Kh0lDUtmlclhjn9CvEK7A7YyRU13PXlNcpSiLI9Yw==",
       "dev": true,
       "requires": {
-        "acorn": "6.1.1",
-        "acorn-dynamic-import": "4.0.0",
-        "acorn-walk": "6.1.1",
-        "xtend": "4.0.1"
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-walk": "^6.1.1",
+        "xtend": "^4.0.1"
       }
     },
     "acorn-walk": {
@@ -40,10 +50,10 @@
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -64,7 +74,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "aproba": {
@@ -103,7 +113,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -112,9 +122,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -123,7 +133,7 @@
       "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
-        "object-assign": "4.1.1",
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -192,7 +202,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bluebird": {
@@ -219,7 +229,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -235,12 +245,12 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "JSONStream": "1.3.5",
-        "safe-buffer": "5.1.2",
-        "through2": "2.0.5",
-        "umd": "3.0.3"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
       }
     },
     "browser-resolve": {
@@ -266,54 +276,54 @@
       "integrity": "sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==",
       "dev": true,
       "requires": {
-        "assert": "1.5.0",
-        "browser-pack": "6.1.0",
-        "browser-resolve": "1.11.3",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.2.1",
-        "cached-path-relative": "1.0.2",
-        "concat-stream": "1.6.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.2.0",
-        "duplexer2": "0.1.4",
-        "events": "2.1.0",
-        "glob": "7.1.4",
-        "has": "1.0.3",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.2.0",
-        "JSONStream": "1.3.5",
-        "labeled-stream-splicer": "2.0.2",
-        "mkdirp": "0.5.1",
-        "module-deps": "6.2.1",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.6",
-        "resolve": "1.11.1",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.2",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.2.0",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.5",
-        "timers-browserify": "1.4.2",
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "^5.0.2",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp": "^0.5.0",
+        "module-deps": "^6.0.0",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
         "tty-browserify": "0.0.1",
-        "url": "0.11.0",
-        "util": "0.10.4",
-        "vm-browserify": "1.1.0",
-        "xtend": "4.0.1"
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -322,10 +332,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -336,12 +346,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cache-api": {
@@ -350,9 +360,9 @@
       "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "async": "^1.5.2",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "browserify-cipher": {
@@ -361,9 +371,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -372,10 +382,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-incremental": {
@@ -384,18 +394,12 @@
       "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
       "dev": true,
       "requires": {
-        "browserify-cache-api": "3.0.1",
-        "JSONStream": "0.10.0",
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "JSONStream": "^0.10.0",
+        "browserify-cache-api": "^3.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
-        "jsonparse": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
-          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
-          "dev": true
-        },
         "JSONStream": {
           "version": "0.10.0",
           "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
@@ -403,8 +407,14 @@
           "dev": true,
           "requires": {
             "jsonparse": "0.0.5",
-            "through": "2.3.8"
+            "through": ">=2.2.7 <3"
           }
+        },
+        "jsonparse": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+          "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+          "dev": true
         }
       }
     },
@@ -414,8 +424,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -424,13 +434,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.1",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.4"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -439,7 +449,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.10"
+        "pako": "~1.0.5"
       }
     },
     "buffer": {
@@ -448,8 +458,8 @@
       "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.13"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-crc32": {
@@ -488,20 +498,20 @@
       "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.5",
-        "chownr": "1.1.2",
-        "figgy-pudding": "3.5.1",
-        "glob": "7.1.4",
-        "graceful-fs": "4.1.15",
-        "lru-cache": "5.1.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.3",
-        "ssri": "6.0.1",
-        "unique-filename": "1.1.1",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
       }
     },
     "cached-path-relative": {
@@ -522,9 +532,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chownr": {
@@ -539,8 +549,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "cli-cursor": {
@@ -549,7 +559,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "color-convert": {
@@ -579,10 +589,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
       }
     },
     "combined-stream": {
@@ -591,7 +601,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -606,10 +616,10 @@
       "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "3.4.0",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -618,9 +628,9 @@
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.2.0",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -631,7 +641,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -652,12 +662,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "core-util-is": {
@@ -672,8 +682,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.1"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -682,11 +692,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -695,12 +705,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -709,11 +719,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.7.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -722,17 +732,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.17",
-        "public-encrypt": "4.0.3",
-        "randombytes": "2.1.0",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "cyclist": {
@@ -753,7 +763,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -780,10 +790,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.5",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.5"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "des.js": {
@@ -792,8 +802,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detective": {
@@ -802,9 +812,9 @@
       "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.7.0",
-        "defined": "1.0.0",
-        "minimist": "1.2.0"
+        "acorn-node": "^1.6.1",
+        "defined": "^1.0.0",
+        "minimist": "^1.1.1"
       }
     },
     "diffie-hellman": {
@@ -813,9 +823,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -830,7 +840,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexify": {
@@ -839,10 +849,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -851,8 +861,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "elliptic": {
@@ -861,13 +871,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.7",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -882,7 +892,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "env-paths": {
@@ -915,8 +925,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.5",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -925,15 +935,15 @@
       "integrity": "sha512-VcQfhuGD51vQUQtKIq2fjGDLDbL6N1DTQVpYzxZ7LPIXw3HqTuIz6uxRmpV1qf8i31LHf2kjiaGI+GdHwRgbnQ==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "5.1.0",
-        "is-stream": "2.0.0",
-        "merge-stream": "2.0.0",
-        "npm-run-path": "3.1.0",
-        "onetime": "5.1.0",
-        "p-finally": "2.0.1",
-        "signal-exit": "3.0.2",
-        "strip-final-newline": "2.0.0"
+        "cross-spawn": "^6.0.5",
+        "get-stream": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^3.0.0",
+        "onetime": "^5.1.0",
+        "p-finally": "^2.0.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
       }
     },
     "extend": {
@@ -978,8 +988,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "forever-agent": {
@@ -994,9 +1004,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.8",
-        "mime-types": "2.1.24"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "from2": {
@@ -1005,8 +1015,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-minipass": {
@@ -1015,7 +1025,7 @@
       "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
-        "minipass": "2.3.5"
+        "minipass": "^2.2.1"
       }
     },
     "fs-write-stream-atomic": {
@@ -1024,10 +1034,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.15",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -1048,7 +1058,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.1"
+        "globule": "^1.0.0"
       }
     },
     "get-assigned-identifiers": {
@@ -1063,7 +1073,7 @@
       "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
       "dev": true,
       "requires": {
-        "pump": "3.0.0"
+        "pump": "^3.0.0"
       }
     },
     "getpass": {
@@ -1072,7 +1082,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1081,12 +1091,12 @@
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globule": {
@@ -1095,9 +1105,9 @@
       "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4",
-        "lodash": "4.17.13",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
       }
     },
     "graceful-fs": {
@@ -1118,8 +1128,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "6.10.2",
-        "har-schema": "2.0.0"
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -1128,7 +1138,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -1143,8 +1153,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -1153,8 +1163,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -1163,9 +1173,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.7",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "htmlescape": {
@@ -1180,9 +1190,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.16.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -1215,8 +1225,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1231,7 +1241,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "~0.5.3"
       }
     },
     "insert-module-globals": {
@@ -1240,16 +1250,16 @@
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.7.0",
-        "combine-source-map": "0.8.0",
-        "concat-stream": "1.6.2",
-        "is-buffer": "1.1.6",
-        "JSONStream": "1.3.5",
-        "path-is-absolute": "1.0.1",
-        "process": "0.11.10",
-        "through2": "2.0.5",
-        "undeclared-identifiers": "1.1.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -1258,10 +1268,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -1338,7 +1348,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1359,16 +1369,6 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1387,8 +1387,8 @@
       "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "stream-splicer": "2.0.1"
+        "inherits": "^2.0.1",
+        "stream-splicer": "^2.0.0"
       }
     },
     "lodash": {
@@ -1409,7 +1409,7 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2"
+        "chalk": "^2.4.2"
       }
     },
     "log-update": {
@@ -1418,9 +1418,9 @@
       "integrity": "sha512-KJ6zAPIHWo7Xg1jYror6IUDFJBq1bQ4Bi4wAEp2y/0ScjBBVi/g0thr0sUVhuvuXauWzczt7T2QHghPDNnKBuw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "cli-cursor": "2.1.0",
-        "wrap-ansi": "5.1.0"
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
       }
     },
     "lru-cache": {
@@ -1429,7 +1429,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "yallist": "3.0.3"
+        "yallist": "^3.0.2"
       }
     },
     "md5.js": {
@@ -1438,9 +1438,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "merge-stream": {
@@ -1455,8 +1455,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -1504,7 +1504,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1519,8 +1519,8 @@
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.3"
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
       }
     },
     "minizlib": {
@@ -1529,7 +1529,7 @@
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "requires": {
-        "minipass": "2.3.5"
+        "minipass": "^2.2.1"
       }
     },
     "mississippi": {
@@ -1538,16 +1538,16 @@
       "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.1.1",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "3.0.0",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.3",
-        "through2": "2.0.5"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -1556,10 +1556,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -1587,21 +1587,21 @@
       "integrity": "sha512-UnEn6Ah36Tu4jFiBbJVUtt0h+iXqxpLqDvPS8nllbw5RZFmNJ1+Mz5BjYnM9ieH80zyxHkARGLnMIHlPK5bu6A==",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.3",
-        "cached-path-relative": "1.0.2",
-        "concat-stream": "1.6.2",
-        "defined": "1.0.0",
-        "detective": "5.2.0",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "JSONStream": "1.3.5",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.6",
-        "resolve": "1.11.1",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.2",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.0.2",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "concat-stream": {
@@ -1610,10 +1610,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         }
       }
@@ -1624,8 +1624,8 @@
       "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "through": "2.2.7"
+        "convert-source-map": "^1.1.0",
+        "through": "~2.2.7"
       },
       "dependencies": {
         "through": {
@@ -1642,12 +1642,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -1674,9 +1674,9 @@
       "integrity": "sha512-zfWC/gICcqb74D9ndyvxZWaI1jzcoHmf4UTHWQchBNuNMxdBLJMDiUgZ1tjGLEIe/BMhj2DxKD8HOuc2062pDQ==",
       "dev": true,
       "requires": {
-        "colors": "1.3.3",
-        "mime": "1.6.0",
-        "optimist": "0.6.1"
+        "colors": ">=0.6.0",
+        "mime": "^1.2.9",
+        "optimist": ">=0.3.4"
       }
     },
     "npm-run-path": {
@@ -1685,7 +1685,7 @@
       "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
       "dev": true,
       "requires": {
-        "path-key": "3.1.0"
+        "path-key": "^3.0.0"
       },
       "dependencies": {
         "path-key": {
@@ -1714,7 +1714,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1723,7 +1723,7 @@
       "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "requires": {
-        "mimic-fn": "2.1.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optimist": {
@@ -1732,8 +1732,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -1774,9 +1774,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "parents": {
@@ -1785,7 +1785,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -1794,12 +1794,12 @@
       "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.17",
-        "safe-buffer": "5.1.2"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "path-browserify": {
@@ -1838,11 +1838,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -1881,12 +1881,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.4",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "pulp": {
@@ -1895,19 +1895,19 @@
       "integrity": "sha512-wjjAVuN1Shx6783NvTd8aPwWZ1pE94+isiWtdAJhedvbLqJuwe8p5CSNul9FS0WvBz7ejdrW0vc6wLDLsKX7Yw==",
       "dev": true,
       "requires": {
-        "browserify": "16.2.3",
-        "browserify-incremental": "3.1.1",
-        "concat-stream": "2.0.0",
-        "gaze": "1.1.3",
-        "glob": "7.1.4",
-        "mold-source-map": "0.4.0",
-        "node-static": "0.7.11",
-        "read": "1.0.7",
-        "sorcery": "0.10.0",
-        "temp": "0.9.0",
-        "through": "2.3.8",
-        "tree-kill": "1.2.1",
-        "which": "1.3.1",
+        "browserify": "^16.2.3",
+        "browserify-incremental": "^3.1.1",
+        "concat-stream": "^2.0.0",
+        "gaze": "^1.1.3",
+        "glob": "^7.1.3",
+        "mold-source-map": "^0.4.0",
+        "node-static": "^0.7.11",
+        "read": "^1.0.7",
+        "sorcery": "^0.10.0",
+        "temp": "^0.9.0",
+        "through": "^2.3.8",
+        "tree-kill": "^1.2.1",
+        "which": "^1.3.1",
         "wordwrap": "1.0.0"
       }
     },
@@ -1917,8 +1917,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -1927,9 +1927,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "pump": {
@@ -1938,8 +1938,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -1956,7 +1956,7 @@
       "integrity": "sha512-PC93xqr0zDs5l5xnfTlptKzv5jBWbML+dwtpDCZkOOH7h9wgLusQfU4PNfHvdwrSmsBntalGm+Cbd6VrokN7Sg==",
       "dev": true,
       "requires": {
-        "purescript-installer": "0.2.5"
+        "purescript-installer": "^0.2.0"
       }
     },
     "purescript-installer": {
@@ -1965,26 +1965,26 @@
       "integrity": "sha512-fQAWWP5a7scuchXecjpU4r4KEgSPuS6bBnaP01k9f71qqD28HaJ2m4PXHFkhkR4oATAxTPIGCtmTwtVoiBOHog==",
       "dev": true,
       "requires": {
-        "arch": "2.1.1",
-        "byline": "5.0.0",
-        "cacache": "11.3.3",
-        "chalk": "2.4.2",
-        "env-paths": "2.2.0",
-        "execa": "2.0.4",
-        "filesize": "4.1.2",
-        "is-plain-obj": "2.0.0",
-        "log-symbols": "3.0.0",
-        "log-update": "3.2.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "ms": "2.1.2",
-        "once": "1.4.0",
-        "pump": "3.0.0",
-        "request": "2.88.0",
-        "rimraf": "2.6.3",
-        "tar": "4.4.10",
-        "which": "1.3.1",
-        "zen-observable": "0.8.14"
+        "arch": "^2.1.1",
+        "byline": "^5.0.0",
+        "cacache": "^11.3.2",
+        "chalk": "^2.4.2",
+        "env-paths": "^2.2.0",
+        "execa": "^2.0.3",
+        "filesize": "^4.1.2",
+        "is-plain-obj": "^2.0.0",
+        "log-symbols": "^3.0.0",
+        "log-update": "^3.2.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "ms": "^2.1.2",
+        "once": "^1.4.0",
+        "pump": "^3.0.0",
+        "request": "^2.88.0",
+        "rimraf": "^2.6.3",
+        "tar": "^4.4.6",
+        "which": "^1.3.1",
+        "zen-observable": "^0.8.14"
       }
     },
     "purescript-psa": {
@@ -2017,7 +2017,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -2026,8 +2026,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "read": {
@@ -2036,7 +2036,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "0.0.8"
+        "mute-stream": "~0.0.4"
       }
     },
     "read-only-stream": {
@@ -2045,7 +2045,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "readable-stream": {
@@ -2054,13 +2054,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "string_decoder": {
@@ -2069,7 +2069,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2080,26 +2080,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.8",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.24",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.3"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "resolve": {
@@ -2108,7 +2108,7 @@
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.6"
       }
     },
     "restore-cursor": {
@@ -2117,8 +2117,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       },
       "dependencies": {
         "mimic-fn": {
@@ -2133,7 +2133,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         }
       }
@@ -2144,7 +2144,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "7.1.4"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {
@@ -2153,8 +2153,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-queue": {
@@ -2163,7 +2163,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "safe-buffer": {
@@ -2184,10 +2184,10 @@
       "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
       "dev": true,
       "requires": {
-        "es6-promise": "3.3.1",
-        "graceful-fs": "4.1.15",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.3"
+        "es6-promise": "^3.1.2",
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
       }
     },
     "semver": {
@@ -2202,8 +2202,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shasum": {
@@ -2212,8 +2212,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.11"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shebang-command": {
@@ -2222,7 +2222,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -2237,10 +2237,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "signal-exit": {
@@ -2261,10 +2261,10 @@
       "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "minimist": "1.2.0",
-        "sander": "0.5.1",
-        "sourcemap-codec": "1.4.4"
+        "buffer-crc32": "^0.2.5",
+        "minimist": "^1.2.0",
+        "sander": "^0.5.0",
+        "sourcemap-codec": "^1.3.0"
       }
     },
     "source-map": {
@@ -2285,15 +2285,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -2302,7 +2302,7 @@
       "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "3.5.1"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "stream-browserify": {
@@ -2311,8 +2311,8 @@
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -2321,8 +2321,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.6"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -2331,8 +2331,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -2341,11 +2341,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -2360,17 +2360,8 @@
       "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
-      }
-    },
-    "string_decoder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "string-width": {
@@ -2379,9 +2370,18 @@
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
-        "emoji-regex": "7.0.3",
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "5.2.0"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -2390,7 +2390,7 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "4.1.0"
+        "ansi-regex": "^4.1.0"
       }
     },
     "strip-final-newline": {
@@ -2405,7 +2405,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       }
     },
     "supports-color": {
@@ -2414,7 +2414,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "syntax-error": {
@@ -2423,7 +2423,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.7.0"
+        "acorn-node": "^1.2.0"
       }
     },
     "tar": {
@@ -2432,13 +2432,13 @@
       "integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
       "dev": true,
       "requires": {
-        "chownr": "1.1.2",
-        "fs-minipass": "1.2.6",
-        "minipass": "2.3.5",
-        "minizlib": "1.2.1",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.3"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.5",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
       }
     },
     "temp": {
@@ -2447,7 +2447,7 @@
       "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
       "dev": true,
       "requires": {
-        "rimraf": "2.6.3"
+        "rimraf": "~2.6.2"
       }
     },
     "through": {
@@ -2462,8 +2462,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "timers-browserify": {
@@ -2472,7 +2472,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "to-arraybuffer": {
@@ -2487,14 +2487,14 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.3.0",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       }
     },
     "tree-kill": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-      "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "tty-browserify": {
@@ -2509,7 +2509,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -2536,11 +2536,11 @@
       "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.7.0",
-        "dash-ast": "1.0.0",
-        "get-assigned-identifiers": "1.2.0",
-        "simple-concat": "1.0.0",
-        "xtend": "4.0.1"
+        "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "unique-filename": {
@@ -2549,7 +2549,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.2"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -2558,7 +2558,7 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "uri-js": {
@@ -2567,7 +2567,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -2623,9 +2623,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -2640,7 +2640,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -2655,9 +2655,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "string-width": "3.1.0",
-        "strip-ansi": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "purescript-elmish-html",
   "description": "Render HTML elements in Elmish",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "private": true,
   "author": "Canopy Education, Inc.",
   "contributors": [

--- a/src/Elmish/HTML/Generated.purs
+++ b/src/Elmish/HTML/Generated.purs
@@ -15,8 +15,12 @@ import Elmish.React.Import
   , ImportedReactComponentConstructorWithContent
   )
 
+import Foreign.Object (Object)
+
+
 type OptProps_a r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -124,7 +128,8 @@ a = createElement $ unsafeCreateDOMComponent "a"
 
 
 type OptProps_abbr r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -225,7 +230,8 @@ abbr = createElement $ unsafeCreateDOMComponent "abbr"
 
 
 type OptProps_address r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -325,7 +331,8 @@ address = createElement $ unsafeCreateDOMComponent "address"
 
 
 type OptProps_area r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -433,7 +440,8 @@ area = createElement' $ unsafeCreateDOMComponent "area"
 
 
 type OptProps_article r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -533,7 +541,8 @@ article = createElement $ unsafeCreateDOMComponent "article"
 
 
 type OptProps_aside r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -633,7 +642,8 @@ aside = createElement $ unsafeCreateDOMComponent "aside"
 
 
 type OptProps_audio r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -738,7 +748,8 @@ audio = createElement $ unsafeCreateDOMComponent "audio"
 
 
 type OptProps_b r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -838,7 +849,8 @@ b = createElement $ unsafeCreateDOMComponent "b"
 
 
 type OptProps_base r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -940,7 +952,8 @@ base = createElement' $ unsafeCreateDOMComponent "base"
 
 
 type OptProps_bdi r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1040,7 +1053,8 @@ bdi = createElement $ unsafeCreateDOMComponent "bdi"
 
 
 type OptProps_bdo r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1141,7 +1155,8 @@ bdo = createElement $ unsafeCreateDOMComponent "bdo"
 
 
 type OptProps_blockquote r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1242,7 +1257,8 @@ blockquote = createElement $ unsafeCreateDOMComponent "blockquote"
 
 
 type OptProps_body r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1342,7 +1358,8 @@ body = createElement $ unsafeCreateDOMComponent "body"
 
 
 type OptProps_br r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1442,7 +1459,8 @@ br = createElement' $ unsafeCreateDOMComponent "br"
 
 
 type OptProps_button r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1547,7 +1565,8 @@ button = createElement $ unsafeCreateDOMComponent "button"
 
 
 type OptProps_canvas r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1649,7 +1668,8 @@ canvas = createElement $ unsafeCreateDOMComponent "canvas"
 
 
 type OptProps_caption r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1749,7 +1769,8 @@ caption = createElement $ unsafeCreateDOMComponent "caption"
 
 
 type OptProps_cite r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1849,7 +1870,8 @@ cite = createElement $ unsafeCreateDOMComponent "cite"
 
 
 type OptProps_code r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -1949,7 +1971,8 @@ code = createElement $ unsafeCreateDOMComponent "code"
 
 
 type OptProps_col r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2051,7 +2074,8 @@ col = createElement' $ unsafeCreateDOMComponent "col"
 
 
 type OptProps_colgroup r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2153,7 +2177,8 @@ colgroup = createElement $ unsafeCreateDOMComponent "colgroup"
 
 
 type OptProps_data r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2254,7 +2279,8 @@ data' = createElement $ unsafeCreateDOMComponent "data"
 
 
 type OptProps_datalist r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2354,7 +2380,8 @@ datalist = createElement $ unsafeCreateDOMComponent "datalist"
 
 
 type OptProps_dd r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2454,7 +2481,8 @@ dd = createElement $ unsafeCreateDOMComponent "dd"
 
 
 type OptProps_del r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2555,7 +2583,8 @@ del = createElement $ unsafeCreateDOMComponent "del"
 
 
 type OptProps_details r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2656,7 +2685,8 @@ details = createElement $ unsafeCreateDOMComponent "details"
 
 
 type OptProps_dfn r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2757,7 +2787,8 @@ dfn = createElement $ unsafeCreateDOMComponent "dfn"
 
 
 type OptProps_dialog r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2858,7 +2889,8 @@ dialog = createElement $ unsafeCreateDOMComponent "dialog"
 
 
 type OptProps_div r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -2958,7 +2990,8 @@ div = createElement $ unsafeCreateDOMComponent "div"
 
 
 type OptProps_dl r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3058,7 +3091,8 @@ dl = createElement $ unsafeCreateDOMComponent "dl"
 
 
 type OptProps_dt r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3158,7 +3192,8 @@ dt = createElement $ unsafeCreateDOMComponent "dt"
 
 
 type OptProps_em r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3258,7 +3293,8 @@ em = createElement $ unsafeCreateDOMComponent "em"
 
 
 type OptProps_embed r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3362,7 +3398,8 @@ embed = createElement' $ unsafeCreateDOMComponent "embed"
 
 
 type OptProps_fieldset r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3465,7 +3502,8 @@ fieldset = createElement $ unsafeCreateDOMComponent "fieldset"
 
 
 type OptProps_figcaption r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3565,7 +3603,8 @@ figcaption = createElement $ unsafeCreateDOMComponent "figcaption"
 
 
 type OptProps_figure r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3665,7 +3704,8 @@ figure = createElement $ unsafeCreateDOMComponent "figure"
 
 
 type OptProps_footer r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3765,7 +3805,8 @@ footer = createElement $ unsafeCreateDOMComponent "footer"
 
 
 type OptProps_form r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , accept :: String
   , acceptCharset :: String
   , accessKey :: String
@@ -3874,7 +3915,8 @@ form = createElement $ unsafeCreateDOMComponent "form"
 
 
 type OptProps_h1 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -3974,7 +4016,8 @@ h1 = createElement $ unsafeCreateDOMComponent "h1"
 
 
 type OptProps_h2 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4074,7 +4117,8 @@ h2 = createElement $ unsafeCreateDOMComponent "h2"
 
 
 type OptProps_h3 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4174,7 +4218,8 @@ h3 = createElement $ unsafeCreateDOMComponent "h3"
 
 
 type OptProps_h4 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4274,7 +4319,8 @@ h4 = createElement $ unsafeCreateDOMComponent "h4"
 
 
 type OptProps_h5 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4374,7 +4420,8 @@ h5 = createElement $ unsafeCreateDOMComponent "h5"
 
 
 type OptProps_h6 r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4474,7 +4521,8 @@ h6 = createElement $ unsafeCreateDOMComponent "h6"
 
 
 type OptProps_head r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4575,7 +4623,8 @@ head = createElement $ unsafeCreateDOMComponent "head"
 
 
 type OptProps_header r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4675,7 +4724,8 @@ header = createElement $ unsafeCreateDOMComponent "header"
 
 
 type OptProps_hgroup r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4775,7 +4825,8 @@ hgroup = createElement $ unsafeCreateDOMComponent "hgroup"
 
 
 type OptProps_hr r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4877,7 +4928,8 @@ hr = createElement' $ unsafeCreateDOMComponent "hr"
 
 
 type OptProps_html r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -4978,7 +5030,8 @@ html = createElement $ unsafeCreateDOMComponent "html"
 
 
 type OptProps_i r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5078,7 +5131,8 @@ i = createElement $ unsafeCreateDOMComponent "i"
 
 
 type OptProps_iframe r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5184,7 +5238,8 @@ iframe = createElement $ unsafeCreateDOMComponent "iframe"
 
 
 type OptProps_img r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5290,7 +5345,8 @@ img = createElement' $ unsafeCreateDOMComponent "img"
 
 
 type OptProps_input r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , accept :: String
   , acceptCharset :: String
   , accessKey :: String
@@ -5418,7 +5474,8 @@ input = createElement' $ unsafeCreateDOMComponent "input"
 
 
 type OptProps_ins r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5519,7 +5576,8 @@ ins = createElement $ unsafeCreateDOMComponent "ins"
 
 
 type OptProps_kbd r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5619,7 +5677,8 @@ kbd = createElement $ unsafeCreateDOMComponent "kbd"
 
 
 type OptProps_keygen r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5723,7 +5782,8 @@ keygen = createElement $ unsafeCreateDOMComponent "keygen"
 
 
 type OptProps_label r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5824,7 +5884,8 @@ label = createElement $ unsafeCreateDOMComponent "label"
 
 
 type OptProps_legend r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -5924,7 +5985,8 @@ legend = createElement $ unsafeCreateDOMComponent "legend"
 
 
 type OptProps_li r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6026,7 +6088,8 @@ li = createElement $ unsafeCreateDOMComponent "li"
 
 
 type OptProps_link r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6137,7 +6200,8 @@ link = createElement' $ unsafeCreateDOMComponent "link"
 
 
 type OptProps_main r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6237,7 +6301,8 @@ main = createElement $ unsafeCreateDOMComponent "main"
 
 
 type OptProps_map r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6338,7 +6403,8 @@ map = createElement $ unsafeCreateDOMComponent "map"
 
 
 type OptProps_mark r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6438,7 +6504,8 @@ mark = createElement $ unsafeCreateDOMComponent "mark"
 
 
 type OptProps_math r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6538,7 +6605,8 @@ math = createElement $ unsafeCreateDOMComponent "math"
 
 
 type OptProps_menu r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6638,7 +6706,8 @@ menu = createElement $ unsafeCreateDOMComponent "menu"
 
 
 type OptProps_menuitem r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6738,7 +6807,8 @@ menuitem = createElement $ unsafeCreateDOMComponent "menuitem"
 
 
 type OptProps_meta r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6840,7 +6910,8 @@ meta = createElement' $ unsafeCreateDOMComponent "meta"
 
 
 type OptProps_meter r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -6946,7 +7017,8 @@ meter = createElement $ unsafeCreateDOMComponent "meter"
 
 
 type OptProps_nav r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7046,7 +7118,8 @@ nav = createElement $ unsafeCreateDOMComponent "nav"
 
 
 type OptProps_noscript r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7146,7 +7219,8 @@ noscript = createElement $ unsafeCreateDOMComponent "noscript"
 
 
 type OptProps_object r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7252,7 +7326,8 @@ object = createElement $ unsafeCreateDOMComponent "object"
 
 
 type OptProps_ol r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7355,7 +7430,8 @@ ol = createElement $ unsafeCreateDOMComponent "ol"
 
 
 type OptProps_optgroup r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7457,7 +7533,8 @@ optgroup = createElement $ unsafeCreateDOMComponent "optgroup"
 
 
 type OptProps_option r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7561,7 +7638,8 @@ option = createElement $ unsafeCreateDOMComponent "option"
 
 
 type OptProps_output r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7663,7 +7741,8 @@ output = createElement $ unsafeCreateDOMComponent "output"
 
 
 type OptProps_p r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7763,7 +7842,8 @@ p = createElement $ unsafeCreateDOMComponent "p"
 
 
 type OptProps_param r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7866,7 +7946,8 @@ param = createElement' $ unsafeCreateDOMComponent "param"
 
 
 type OptProps_picture r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -7966,7 +8047,8 @@ picture = createElement $ unsafeCreateDOMComponent "picture"
 
 
 type OptProps_pre r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8067,7 +8149,8 @@ pre = createElement $ unsafeCreateDOMComponent "pre"
 
 
 type OptProps_progress r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8169,7 +8252,8 @@ progress = createElement $ unsafeCreateDOMComponent "progress"
 
 
 type OptProps_q r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8270,7 +8354,8 @@ q = createElement $ unsafeCreateDOMComponent "q"
 
 
 type OptProps_rb r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8370,7 +8455,8 @@ rb = createElement $ unsafeCreateDOMComponent "rb"
 
 
 type OptProps_rp r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8470,7 +8556,8 @@ rp = createElement $ unsafeCreateDOMComponent "rp"
 
 
 type OptProps_rt r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8570,7 +8657,8 @@ rt = createElement $ unsafeCreateDOMComponent "rt"
 
 
 type OptProps_rtc r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8670,7 +8758,8 @@ rtc = createElement $ unsafeCreateDOMComponent "rtc"
 
 
 type OptProps_ruby r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8770,7 +8859,8 @@ ruby = createElement $ unsafeCreateDOMComponent "ruby"
 
 
 type OptProps_s r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8870,7 +8960,8 @@ s = createElement $ unsafeCreateDOMComponent "s"
 
 
 type OptProps_samp r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -8970,7 +9061,8 @@ samp = createElement $ unsafeCreateDOMComponent "samp"
 
 
 type OptProps_script r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9076,7 +9168,8 @@ script = createElement $ unsafeCreateDOMComponent "script"
 
 
 type OptProps_section r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9176,7 +9269,8 @@ section = createElement $ unsafeCreateDOMComponent "section"
 
 
 type OptProps_select r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9285,7 +9379,8 @@ select = createElement $ unsafeCreateDOMComponent "select"
 
 
 type OptProps_slot r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9386,7 +9481,8 @@ slot = createElement $ unsafeCreateDOMComponent "slot"
 
 
 type OptProps_small r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9486,7 +9582,8 @@ small = createElement $ unsafeCreateDOMComponent "small"
 
 
 type OptProps_source r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9590,7 +9687,8 @@ source = createElement' $ unsafeCreateDOMComponent "source"
 
 
 type OptProps_span r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9690,7 +9788,8 @@ span = createElement $ unsafeCreateDOMComponent "span"
 
 
 type OptProps_strong r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9790,7 +9889,8 @@ strong = createElement $ unsafeCreateDOMComponent "strong"
 
 
 type OptProps_style r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9894,7 +9994,8 @@ style = createElement $ unsafeCreateDOMComponent "style"
 
 
 type OptProps_sub r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -9994,7 +10095,8 @@ sub = createElement $ unsafeCreateDOMComponent "sub"
 
 
 type OptProps_summary r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10094,7 +10196,8 @@ summary = createElement $ unsafeCreateDOMComponent "summary"
 
 
 type OptProps_sup r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10194,7 +10297,8 @@ sup = createElement $ unsafeCreateDOMComponent "sup"
 
 
 type OptProps_svg r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , accentHeight :: String
   , acceptCharset :: String
   , accessKey :: String
@@ -10536,7 +10640,8 @@ svg = createElement $ unsafeCreateDOMComponent "svg"
 
 
 type OptProps_table r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10638,7 +10743,8 @@ table = createElement $ unsafeCreateDOMComponent "table"
 
 
 type OptProps_tbody r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10738,7 +10844,8 @@ tbody = createElement $ unsafeCreateDOMComponent "tbody"
 
 
 type OptProps_td r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10842,7 +10949,8 @@ td = createElement $ unsafeCreateDOMComponent "td"
 
 
 type OptProps_template r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -10942,7 +11050,8 @@ template = createElement $ unsafeCreateDOMComponent "template"
 
 
 type OptProps_textarea r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11055,7 +11164,8 @@ textarea = createElement $ unsafeCreateDOMComponent "textarea"
 
 
 type OptProps_tfoot r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11155,7 +11265,8 @@ tfoot = createElement $ unsafeCreateDOMComponent "tfoot"
 
 
 type OptProps_th r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11259,7 +11370,8 @@ th = createElement $ unsafeCreateDOMComponent "th"
 
 
 type OptProps_thead r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11359,7 +11471,8 @@ thead = createElement $ unsafeCreateDOMComponent "thead"
 
 
 type OptProps_time r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11459,7 +11572,8 @@ time = createElement $ unsafeCreateDOMComponent "time"
 
 
 type OptProps_title r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11559,7 +11673,8 @@ title = createElement $ unsafeCreateDOMComponent "title"
 
 
 type OptProps_tr r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11659,7 +11774,8 @@ tr = createElement $ unsafeCreateDOMComponent "tr"
 
 
 type OptProps_track r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11763,7 +11879,8 @@ track = createElement' $ unsafeCreateDOMComponent "track"
 
 
 type OptProps_u r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11863,7 +11980,8 @@ u = createElement $ unsafeCreateDOMComponent "u"
 
 
 type OptProps_ul r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -11964,7 +12082,8 @@ ul = createElement $ unsafeCreateDOMComponent "ul"
 
 
 type OptProps_var r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -12064,7 +12183,8 @@ var = createElement $ unsafeCreateDOMComponent "var"
 
 
 type OptProps_video r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean
@@ -12173,7 +12293,8 @@ video = createElement $ unsafeCreateDOMComponent "video"
 
 
 type OptProps_wbr r =
-  ( about :: String
+  ( _data :: Object String
+  , about :: String
   , acceptCharset :: String
   , accessKey :: String
   , allowFullScreen :: Boolean


### PR DESCRIPTION
Usage:

```purescript
import Foreign.Object as FO

H.div
  { _data: FO.fromHomogenous { toggle: "buttons } }
  [...]
```

See individual commits for change descriptions.

Inspired by `purescript-react-basic`.

See: https://github.com/collegevine/purescript-elmish/pull/12