### PR TITLE
Styled tags

### DIFF
--- a/codegen/html.js
+++ b/codegen/html.js
@@ -1,0 +1,76 @@
+const { props, voids, types, typesByElement, reserved } = require("./consts")
+
+module.exports = () => ({
+  path: "Elmish/HTML/Generated.purs",
+  content: header + domTypes(),
+})
+
+const header = `-- | ---------------------------------------------------------------------------
+-- | THIS FILE IS GENERATED -- DO NOT EDIT IT
+-- | ---------------------------------------------------------------------------
+
+module Elmish.HTML.Generated where
+
+import Prelude
+
+import Elmish (JsCallback0)
+import Elmish.React (ReactElement, createElement, createElement')
+import Elmish.HTML.Internal (CSS, unsafeCreateDOMComponent)
+import Elmish.React.Import
+  ( EmptyProps
+  , ImportedReactComponentConstructor
+  , ImportedReactComponentConstructorWithContent
+  )
+
+import Foreign.Object (Object)
+
+
+`
+
+const propType = (e, p) => {
+  const elPropTypes = typesByElement[p]
+  if (elPropTypes) {
+    if (types[p]) {
+      throw new TypeError(`${p} appears in both types and typesByElement`)
+    }
+    return elPropTypes[e] || elPropTypes["*"] || "String"
+  } else {
+    return types[p] || "String"
+  }
+}
+
+const printRow = (e, elProps) =>
+  elProps.length > 0
+    ? `
+  ( _data :: Object String
+  , ${elProps.map(p => `${p} :: ${propType(e, p)}`).join("\n  , ")}
+  | r
+  )`
+    : "( | r )"
+
+const domTypes = () =>
+  props.elements.html
+    .map(e => {
+      const hasChildren = !voids.includes(e)
+      const symbol = reserved.includes(e) ? `${e}'` : e
+      return `
+    type OptProps_${e} r =${printRow(
+        e,
+        [].concat(props[e] || [], props["*"] || []).sort()
+      )}
+
+    ${
+      hasChildren
+        ? `
+    ${symbol} :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_${e}
+    ${symbol} = createElement $ unsafeCreateDOMComponent "${e}"
+    `
+        : `
+    ${symbol} :: ImportedReactComponentConstructor EmptyProps OptProps_${e}
+    ${symbol} = createElement' $ unsafeCreateDOMComponent "${e}"
+    `
+    }
+`
+    })
+    .map(x => x.replace(/^\n\ {4}/, "").replace(/\n\ {4}/g, "\n"))
+    .join("\n")

--- a/codegen/styled.js
+++ b/codegen/styled.js
@@ -1,0 +1,31 @@
+const { props, voids, types, typesByElement, reserved } = require("./consts")
+
+module.exports = () => ({
+  path: "Elmish/HTML/Styled/Generated.purs",
+  content: header + content(),
+})
+
+const header = `-- | ---------------------------------------------------------------------------
+-- | THIS FILE IS GENERATED -- DO NOT EDIT IT
+-- | ---------------------------------------------------------------------------
+
+module Elmish.HTML.Styled.Generated where
+
+import Elmish.HTML.Generated as H
+import Elmish.HTML.Internal as I
+
+
+`
+
+const content = () =>
+  props.elements.html
+    .map(e => {
+      const noContent = voids.includes(e) ? "NoContent" : ""
+      const symbol = reserved.includes(e) ? `${e}'` : e
+      return `
+    ${symbol} = I.styledTag${noContent} "${e}" :: I.StyledTag${noContent}
+    ${symbol}_ = I.styledTag${noContent}_ "${e}" :: I.StyledTag${noContent}_ H.OptProps_${e}
+    `
+    })
+    .map(x => x.replace(/^\n\ {4}/, "").replace(/\n\ {4}/g, "\n"))
+    .join("\n")

--- a/src/Elmish/HTML.purs
+++ b/src/Elmish/HTML.purs
@@ -1,7 +1,9 @@
 module Elmish.HTML
-    ( module Exported
+    ( module ExportedDOM
+    , module ExportedGen
+    , module ExportedInt
     ) where
 
-import Elmish.React.DOM (text) as Exported
-import Elmish.HTML.Generated as Exported
-import Elmish.HTML.Internal (CSS) as Exported
+import Elmish.React.DOM (text) as ExportedDOM
+import Elmish.HTML.Generated as ExportedGen
+import Elmish.HTML.Internal (CSS, css) as ExportedInt

--- a/src/Elmish/HTML.purs
+++ b/src/Elmish/HTML.purs
@@ -6,4 +6,4 @@ module Elmish.HTML
 
 import Elmish.React.DOM (text) as ExportedDOM
 import Elmish.HTML.Generated as ExportedGen
-import Elmish.HTML.Internal (CSS, css) as ExportedInt
+import Elmish.HTML.Internal (CSS, css) as ExportedInternal

--- a/src/Elmish/HTML.purs
+++ b/src/Elmish/HTML.purs
@@ -1,7 +1,7 @@
 module Elmish.HTML
     ( module ExportedDOM
     , module ExportedGen
-    , module ExportedInt
+    , module ExportedInternal
     ) where
 
 import Elmish.React.DOM (text) as ExportedDOM

--- a/src/Elmish/HTML/Internal.purs
+++ b/src/Elmish/HTML/Internal.purs
@@ -8,7 +8,6 @@ import Elmish.React (class ReactChildren, class ValidReactProps)
 import Elmish.React.Import (class IsSubsetOf, CommonProps, ImportedReactComponent)
 import Record (merge)
 import Type.Row (type (+))
-import Type.Row.Homogeneous (class Homogeneous)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | The type of `style` props in React elements. Construct values of this type
@@ -21,14 +20,14 @@ instance jsCSS :: CanPassToJavaScript CSS
 
 
 -- | Construct a value of type `CSS`, which is the type of `style` props, out of
--- | a record with all `String` values. For example:
+-- | a record. For example:
 -- |
 -- |    div { style: css { height: "50px", width: "50px" } }
 -- |
 -- | There is currently no type safety regarding the specific fields admitted in
 -- | the style, or different types of those fields. This has been deemed "good
 -- | enough" for now.
-css :: forall r. Homogeneous r String => { | r } -> CSS
+css :: forall r. { | r } -> CSS
 css = unsafeCoerce
 
 

--- a/src/Elmish/HTML/Internal.purs
+++ b/src/Elmish/HTML/Internal.purs
@@ -1,9 +1,90 @@
 module Elmish.HTML.Internal where
 
-import Elmish.React.Import (ImportedReactComponent)
+import Prelude
+
+import Elmish (ReactElement, createElement, createElement')
+import Elmish.Foreign (class CanPassToJavaScript)
+import Elmish.React (class ReactChildren, class ValidReactProps)
+import Elmish.React.Import (class IsSubsetOf, CommonProps, ImportedReactComponent)
+import Record (merge)
+import Type.Row (type (+))
+import Type.Row.Homogeneous (class Homogeneous)
 import Unsafe.Coerce (unsafeCoerce)
 
+-- | The type of `style` props in React elements. Construct values of this type
+-- | via the `css` function. For example:
+-- |
+-- |    div { style: css { height: "50px", width: "50px" } }
+-- |
 foreign import data CSS :: Type
+instance jsCSS :: CanPassToJavaScript CSS
 
+
+-- | Construct a value of type `CSS`, which is the type of `style` props, out of
+-- | a record with all `String` values. For example:
+-- |
+-- |    div { style: css { height: "50px", width: "50px" } }
+-- |
+-- | There is currently no type safety regarding the specific fields admitted in
+-- | the style, or different types of those fields. This has been deemed "good
+-- | enough" for now.
+css :: forall r. Homogeneous r String => { | r } -> CSS
+css = unsafeCoerce
+
+
+-- | Retype a string as a React component, which is something that React
+-- | supports out of the box - i.e. a string "div" can be used in place of a
+-- | `React.Component`-descendant class
 unsafeCreateDOMComponent :: String -> ImportedReactComponent
 unsafeCreateDOMComponent = unsafeCoerce
+
+
+-- | A CSS-framework-friendly tag-creating function with props. The `reqProps`
+-- | type parameter is a row of optional props for this tag. The point of
+-- | CSS-framework-friendliness is that the `className` prop is given as first
+-- | parameter rather than being part of the other props, so we can write `div_
+-- | "row" {}` rather than `div { className: "row" }`
+type StyledTag_ optProps =
+  forall props content
+   . ReactChildren content
+  => IsSubsetOf props (optProps + CommonProps)
+  => ValidReactProps { | props }
+  => String -> { | props } -> content -> ReactElement
+
+-- | A CSS-framework-friendly tag-creating function without props. The point of
+-- | CSS-framework-friendliness is that the `className` prop is given as first
+-- | parameter rather than being part of the other props, so we can write `div
+-- | "row"` rather than `div { className: "row" }`
+type StyledTag =
+  forall content. ReactChildren content => String -> content -> ReactElement
+
+-- | See comments on `StyledTag`
+type StyledTagNoContent = String -> ReactElement
+
+-- | See comments on `StyledTag_`
+type StyledTagNoContent_ optProps =
+  forall props
+   . IsSubsetOf props (optProps + CommonProps)
+  => ValidReactProps { | props }
+  => String -> { | props } -> ReactElement
+
+styledTag_ :: forall props content
+   . ReactChildren content
+  => ValidReactProps props
+  => String -> String -> props -> content -> ReactElement
+styledTag_ tag cls props =
+  createElement (unsafeCreateDOMComponent tag) $ (unsafeCoerce props :: {}) `merge` { className: cls }
+
+styledTag :: String -> StyledTag
+styledTag tag cls content =
+  createElement (unsafeCreateDOMComponent tag) { className: cls } content
+
+styledTagNoContent :: String -> StyledTagNoContent
+styledTagNoContent tag cls =
+  createElement' (unsafeCreateDOMComponent tag) { className: cls }
+
+styledTagNoContent_ :: forall props
+   . ValidReactProps props
+  => String -> String -> props -> ReactElement
+styledTagNoContent_ tag cls props =
+  createElement' (unsafeCreateDOMComponent tag) $ (unsafeCoerce props :: {}) `merge` { className: cls }

--- a/src/Elmish/HTML/Styled.purs
+++ b/src/Elmish/HTML/Styled.purs
@@ -31,9 +31,9 @@
 module Elmish.HTML.Styled
     ( module ExportedDOM
     , module ExportedGen
-    , module ExportedInt
+    , module ExportedInternal
     ) where
 
 import Elmish.React.DOM (text) as ExportedDOM
 import Elmish.HTML.Styled.Generated as ExportedGen
-import Elmish.HTML.Internal (CSS, css) as ExportedInt
+import Elmish.HTML.Internal (CSS, css) as ExportedInternal

--- a/src/Elmish/HTML/Styled.purs
+++ b/src/Elmish/HTML/Styled.purs
@@ -1,0 +1,39 @@
+-- | This module exports all the primitive HTML elements in a way that is
+-- | friendly to CSS frameworks (such as Bootstrap), which means promoting the
+-- | `className` prop to the first parameter and optionally dropping all other
+-- | props completely. This lets us write:
+-- |
+-- |     div "row" $
+-- |       div "col pl-5 border-right" $
+-- |         "Hellow Bootstrap!"
+-- |
+-- | Instead of:
+-- |
+-- |     div { className: "row" } $
+-- |       div { className: "col pl-5 border-right" } $
+-- |         "Hellow Bootstrap!"
+-- |
+-- | The improvement may seem marginal, but it makes a big difference in the
+-- | day-to-day UI authoring.
+-- |
+-- | Each tag comes in two flavors: without any props besides the class, and
+-- | with other props. The former is named after the element (e.g. `div`), and
+-- | the latter has an extra underscore at the end (e.g. `div_`). This is done
+-- | because, in practice, most elements don't have any props besides `div`, so
+-- | it makes the code that much less noisy. For example:
+-- |
+-- |     div_ "row" { onClick: click } $
+-- |       div "col pl-5 border-right" $
+-- |         [ img_ "img-fluid" { src: "/logo.png" }
+-- |         , DOM.text "Hellow Elmish!"
+-- |         ]
+-- |
+module Elmish.HTML.Styled
+    ( module ExportedDOM
+    , module ExportedGen
+    , module ExportedInt
+    ) where
+
+import Elmish.React.DOM (text) as ExportedDOM
+import Elmish.HTML.Styled.Generated as ExportedGen
+import Elmish.HTML.Internal (CSS, css) as ExportedInt

--- a/src/Elmish/HTML/Styled/Generated.purs
+++ b/src/Elmish/HTML/Styled/Generated.purs
@@ -1,0 +1,363 @@
+-- | ---------------------------------------------------------------------------
+-- | THIS FILE IS GENERATED -- DO NOT EDIT IT
+-- | ---------------------------------------------------------------------------
+
+module Elmish.HTML.Styled.Generated where
+
+import Elmish.HTML.Generated as H
+import Elmish.HTML.Internal as I
+
+
+a = I.styledTag "a" :: I.StyledTag
+a_ = I.styledTag_ "a" :: I.StyledTag_ H.OptProps_a
+
+abbr = I.styledTag "abbr" :: I.StyledTag
+abbr_ = I.styledTag_ "abbr" :: I.StyledTag_ H.OptProps_abbr
+
+address = I.styledTag "address" :: I.StyledTag
+address_ = I.styledTag_ "address" :: I.StyledTag_ H.OptProps_address
+
+area = I.styledTagNoContent "area" :: I.StyledTagNoContent
+area_ = I.styledTagNoContent_ "area" :: I.StyledTagNoContent_ H.OptProps_area
+
+article = I.styledTag "article" :: I.StyledTag
+article_ = I.styledTag_ "article" :: I.StyledTag_ H.OptProps_article
+
+aside = I.styledTag "aside" :: I.StyledTag
+aside_ = I.styledTag_ "aside" :: I.StyledTag_ H.OptProps_aside
+
+audio = I.styledTag "audio" :: I.StyledTag
+audio_ = I.styledTag_ "audio" :: I.StyledTag_ H.OptProps_audio
+
+b = I.styledTag "b" :: I.StyledTag
+b_ = I.styledTag_ "b" :: I.StyledTag_ H.OptProps_b
+
+base = I.styledTagNoContent "base" :: I.StyledTagNoContent
+base_ = I.styledTagNoContent_ "base" :: I.StyledTagNoContent_ H.OptProps_base
+
+bdi = I.styledTag "bdi" :: I.StyledTag
+bdi_ = I.styledTag_ "bdi" :: I.StyledTag_ H.OptProps_bdi
+
+bdo = I.styledTag "bdo" :: I.StyledTag
+bdo_ = I.styledTag_ "bdo" :: I.StyledTag_ H.OptProps_bdo
+
+blockquote = I.styledTag "blockquote" :: I.StyledTag
+blockquote_ = I.styledTag_ "blockquote" :: I.StyledTag_ H.OptProps_blockquote
+
+body = I.styledTag "body" :: I.StyledTag
+body_ = I.styledTag_ "body" :: I.StyledTag_ H.OptProps_body
+
+br = I.styledTagNoContent "br" :: I.StyledTagNoContent
+br_ = I.styledTagNoContent_ "br" :: I.StyledTagNoContent_ H.OptProps_br
+
+button = I.styledTag "button" :: I.StyledTag
+button_ = I.styledTag_ "button" :: I.StyledTag_ H.OptProps_button
+
+canvas = I.styledTag "canvas" :: I.StyledTag
+canvas_ = I.styledTag_ "canvas" :: I.StyledTag_ H.OptProps_canvas
+
+caption = I.styledTag "caption" :: I.StyledTag
+caption_ = I.styledTag_ "caption" :: I.StyledTag_ H.OptProps_caption
+
+cite = I.styledTag "cite" :: I.StyledTag
+cite_ = I.styledTag_ "cite" :: I.StyledTag_ H.OptProps_cite
+
+code = I.styledTag "code" :: I.StyledTag
+code_ = I.styledTag_ "code" :: I.StyledTag_ H.OptProps_code
+
+col = I.styledTagNoContent "col" :: I.StyledTagNoContent
+col_ = I.styledTagNoContent_ "col" :: I.StyledTagNoContent_ H.OptProps_col
+
+colgroup = I.styledTag "colgroup" :: I.StyledTag
+colgroup_ = I.styledTag_ "colgroup" :: I.StyledTag_ H.OptProps_colgroup
+
+data' = I.styledTag "data" :: I.StyledTag
+data'_ = I.styledTag_ "data" :: I.StyledTag_ H.OptProps_data
+
+datalist = I.styledTag "datalist" :: I.StyledTag
+datalist_ = I.styledTag_ "datalist" :: I.StyledTag_ H.OptProps_datalist
+
+dd = I.styledTag "dd" :: I.StyledTag
+dd_ = I.styledTag_ "dd" :: I.StyledTag_ H.OptProps_dd
+
+del = I.styledTag "del" :: I.StyledTag
+del_ = I.styledTag_ "del" :: I.StyledTag_ H.OptProps_del
+
+details = I.styledTag "details" :: I.StyledTag
+details_ = I.styledTag_ "details" :: I.StyledTag_ H.OptProps_details
+
+dfn = I.styledTag "dfn" :: I.StyledTag
+dfn_ = I.styledTag_ "dfn" :: I.StyledTag_ H.OptProps_dfn
+
+dialog = I.styledTag "dialog" :: I.StyledTag
+dialog_ = I.styledTag_ "dialog" :: I.StyledTag_ H.OptProps_dialog
+
+div = I.styledTag "div" :: I.StyledTag
+div_ = I.styledTag_ "div" :: I.StyledTag_ H.OptProps_div
+
+dl = I.styledTag "dl" :: I.StyledTag
+dl_ = I.styledTag_ "dl" :: I.StyledTag_ H.OptProps_dl
+
+dt = I.styledTag "dt" :: I.StyledTag
+dt_ = I.styledTag_ "dt" :: I.StyledTag_ H.OptProps_dt
+
+em = I.styledTag "em" :: I.StyledTag
+em_ = I.styledTag_ "em" :: I.StyledTag_ H.OptProps_em
+
+embed = I.styledTagNoContent "embed" :: I.StyledTagNoContent
+embed_ = I.styledTagNoContent_ "embed" :: I.StyledTagNoContent_ H.OptProps_embed
+
+fieldset = I.styledTag "fieldset" :: I.StyledTag
+fieldset_ = I.styledTag_ "fieldset" :: I.StyledTag_ H.OptProps_fieldset
+
+figcaption = I.styledTag "figcaption" :: I.StyledTag
+figcaption_ = I.styledTag_ "figcaption" :: I.StyledTag_ H.OptProps_figcaption
+
+figure = I.styledTag "figure" :: I.StyledTag
+figure_ = I.styledTag_ "figure" :: I.StyledTag_ H.OptProps_figure
+
+footer = I.styledTag "footer" :: I.StyledTag
+footer_ = I.styledTag_ "footer" :: I.StyledTag_ H.OptProps_footer
+
+form = I.styledTag "form" :: I.StyledTag
+form_ = I.styledTag_ "form" :: I.StyledTag_ H.OptProps_form
+
+h1 = I.styledTag "h1" :: I.StyledTag
+h1_ = I.styledTag_ "h1" :: I.StyledTag_ H.OptProps_h1
+
+h2 = I.styledTag "h2" :: I.StyledTag
+h2_ = I.styledTag_ "h2" :: I.StyledTag_ H.OptProps_h2
+
+h3 = I.styledTag "h3" :: I.StyledTag
+h3_ = I.styledTag_ "h3" :: I.StyledTag_ H.OptProps_h3
+
+h4 = I.styledTag "h4" :: I.StyledTag
+h4_ = I.styledTag_ "h4" :: I.StyledTag_ H.OptProps_h4
+
+h5 = I.styledTag "h5" :: I.StyledTag
+h5_ = I.styledTag_ "h5" :: I.StyledTag_ H.OptProps_h5
+
+h6 = I.styledTag "h6" :: I.StyledTag
+h6_ = I.styledTag_ "h6" :: I.StyledTag_ H.OptProps_h6
+
+head = I.styledTag "head" :: I.StyledTag
+head_ = I.styledTag_ "head" :: I.StyledTag_ H.OptProps_head
+
+header = I.styledTag "header" :: I.StyledTag
+header_ = I.styledTag_ "header" :: I.StyledTag_ H.OptProps_header
+
+hgroup = I.styledTag "hgroup" :: I.StyledTag
+hgroup_ = I.styledTag_ "hgroup" :: I.StyledTag_ H.OptProps_hgroup
+
+hr = I.styledTagNoContent "hr" :: I.StyledTagNoContent
+hr_ = I.styledTagNoContent_ "hr" :: I.StyledTagNoContent_ H.OptProps_hr
+
+html = I.styledTag "html" :: I.StyledTag
+html_ = I.styledTag_ "html" :: I.StyledTag_ H.OptProps_html
+
+i = I.styledTag "i" :: I.StyledTag
+i_ = I.styledTag_ "i" :: I.StyledTag_ H.OptProps_i
+
+iframe = I.styledTag "iframe" :: I.StyledTag
+iframe_ = I.styledTag_ "iframe" :: I.StyledTag_ H.OptProps_iframe
+
+img = I.styledTagNoContent "img" :: I.StyledTagNoContent
+img_ = I.styledTagNoContent_ "img" :: I.StyledTagNoContent_ H.OptProps_img
+
+input = I.styledTagNoContent "input" :: I.StyledTagNoContent
+input_ = I.styledTagNoContent_ "input" :: I.StyledTagNoContent_ H.OptProps_input
+
+ins = I.styledTag "ins" :: I.StyledTag
+ins_ = I.styledTag_ "ins" :: I.StyledTag_ H.OptProps_ins
+
+kbd = I.styledTag "kbd" :: I.StyledTag
+kbd_ = I.styledTag_ "kbd" :: I.StyledTag_ H.OptProps_kbd
+
+keygen = I.styledTag "keygen" :: I.StyledTag
+keygen_ = I.styledTag_ "keygen" :: I.StyledTag_ H.OptProps_keygen
+
+label = I.styledTag "label" :: I.StyledTag
+label_ = I.styledTag_ "label" :: I.StyledTag_ H.OptProps_label
+
+legend = I.styledTag "legend" :: I.StyledTag
+legend_ = I.styledTag_ "legend" :: I.StyledTag_ H.OptProps_legend
+
+li = I.styledTag "li" :: I.StyledTag
+li_ = I.styledTag_ "li" :: I.StyledTag_ H.OptProps_li
+
+link = I.styledTagNoContent "link" :: I.StyledTagNoContent
+link_ = I.styledTagNoContent_ "link" :: I.StyledTagNoContent_ H.OptProps_link
+
+main = I.styledTag "main" :: I.StyledTag
+main_ = I.styledTag_ "main" :: I.StyledTag_ H.OptProps_main
+
+map = I.styledTag "map" :: I.StyledTag
+map_ = I.styledTag_ "map" :: I.StyledTag_ H.OptProps_map
+
+mark = I.styledTag "mark" :: I.StyledTag
+mark_ = I.styledTag_ "mark" :: I.StyledTag_ H.OptProps_mark
+
+math = I.styledTag "math" :: I.StyledTag
+math_ = I.styledTag_ "math" :: I.StyledTag_ H.OptProps_math
+
+menu = I.styledTag "menu" :: I.StyledTag
+menu_ = I.styledTag_ "menu" :: I.StyledTag_ H.OptProps_menu
+
+menuitem = I.styledTag "menuitem" :: I.StyledTag
+menuitem_ = I.styledTag_ "menuitem" :: I.StyledTag_ H.OptProps_menuitem
+
+meta = I.styledTagNoContent "meta" :: I.StyledTagNoContent
+meta_ = I.styledTagNoContent_ "meta" :: I.StyledTagNoContent_ H.OptProps_meta
+
+meter = I.styledTag "meter" :: I.StyledTag
+meter_ = I.styledTag_ "meter" :: I.StyledTag_ H.OptProps_meter
+
+nav = I.styledTag "nav" :: I.StyledTag
+nav_ = I.styledTag_ "nav" :: I.StyledTag_ H.OptProps_nav
+
+noscript = I.styledTag "noscript" :: I.StyledTag
+noscript_ = I.styledTag_ "noscript" :: I.StyledTag_ H.OptProps_noscript
+
+object = I.styledTag "object" :: I.StyledTag
+object_ = I.styledTag_ "object" :: I.StyledTag_ H.OptProps_object
+
+ol = I.styledTag "ol" :: I.StyledTag
+ol_ = I.styledTag_ "ol" :: I.StyledTag_ H.OptProps_ol
+
+optgroup = I.styledTag "optgroup" :: I.StyledTag
+optgroup_ = I.styledTag_ "optgroup" :: I.StyledTag_ H.OptProps_optgroup
+
+option = I.styledTag "option" :: I.StyledTag
+option_ = I.styledTag_ "option" :: I.StyledTag_ H.OptProps_option
+
+output = I.styledTag "output" :: I.StyledTag
+output_ = I.styledTag_ "output" :: I.StyledTag_ H.OptProps_output
+
+p = I.styledTag "p" :: I.StyledTag
+p_ = I.styledTag_ "p" :: I.StyledTag_ H.OptProps_p
+
+param = I.styledTagNoContent "param" :: I.StyledTagNoContent
+param_ = I.styledTagNoContent_ "param" :: I.StyledTagNoContent_ H.OptProps_param
+
+picture = I.styledTag "picture" :: I.StyledTag
+picture_ = I.styledTag_ "picture" :: I.StyledTag_ H.OptProps_picture
+
+pre = I.styledTag "pre" :: I.StyledTag
+pre_ = I.styledTag_ "pre" :: I.StyledTag_ H.OptProps_pre
+
+progress = I.styledTag "progress" :: I.StyledTag
+progress_ = I.styledTag_ "progress" :: I.StyledTag_ H.OptProps_progress
+
+q = I.styledTag "q" :: I.StyledTag
+q_ = I.styledTag_ "q" :: I.StyledTag_ H.OptProps_q
+
+rb = I.styledTag "rb" :: I.StyledTag
+rb_ = I.styledTag_ "rb" :: I.StyledTag_ H.OptProps_rb
+
+rp = I.styledTag "rp" :: I.StyledTag
+rp_ = I.styledTag_ "rp" :: I.StyledTag_ H.OptProps_rp
+
+rt = I.styledTag "rt" :: I.StyledTag
+rt_ = I.styledTag_ "rt" :: I.StyledTag_ H.OptProps_rt
+
+rtc = I.styledTag "rtc" :: I.StyledTag
+rtc_ = I.styledTag_ "rtc" :: I.StyledTag_ H.OptProps_rtc
+
+ruby = I.styledTag "ruby" :: I.StyledTag
+ruby_ = I.styledTag_ "ruby" :: I.StyledTag_ H.OptProps_ruby
+
+s = I.styledTag "s" :: I.StyledTag
+s_ = I.styledTag_ "s" :: I.StyledTag_ H.OptProps_s
+
+samp = I.styledTag "samp" :: I.StyledTag
+samp_ = I.styledTag_ "samp" :: I.StyledTag_ H.OptProps_samp
+
+script = I.styledTag "script" :: I.StyledTag
+script_ = I.styledTag_ "script" :: I.StyledTag_ H.OptProps_script
+
+section = I.styledTag "section" :: I.StyledTag
+section_ = I.styledTag_ "section" :: I.StyledTag_ H.OptProps_section
+
+select = I.styledTag "select" :: I.StyledTag
+select_ = I.styledTag_ "select" :: I.StyledTag_ H.OptProps_select
+
+slot = I.styledTag "slot" :: I.StyledTag
+slot_ = I.styledTag_ "slot" :: I.StyledTag_ H.OptProps_slot
+
+small = I.styledTag "small" :: I.StyledTag
+small_ = I.styledTag_ "small" :: I.StyledTag_ H.OptProps_small
+
+source = I.styledTagNoContent "source" :: I.StyledTagNoContent
+source_ = I.styledTagNoContent_ "source" :: I.StyledTagNoContent_ H.OptProps_source
+
+span = I.styledTag "span" :: I.StyledTag
+span_ = I.styledTag_ "span" :: I.StyledTag_ H.OptProps_span
+
+strong = I.styledTag "strong" :: I.StyledTag
+strong_ = I.styledTag_ "strong" :: I.StyledTag_ H.OptProps_strong
+
+style = I.styledTag "style" :: I.StyledTag
+style_ = I.styledTag_ "style" :: I.StyledTag_ H.OptProps_style
+
+sub = I.styledTag "sub" :: I.StyledTag
+sub_ = I.styledTag_ "sub" :: I.StyledTag_ H.OptProps_sub
+
+summary = I.styledTag "summary" :: I.StyledTag
+summary_ = I.styledTag_ "summary" :: I.StyledTag_ H.OptProps_summary
+
+sup = I.styledTag "sup" :: I.StyledTag
+sup_ = I.styledTag_ "sup" :: I.StyledTag_ H.OptProps_sup
+
+svg = I.styledTag "svg" :: I.StyledTag
+svg_ = I.styledTag_ "svg" :: I.StyledTag_ H.OptProps_svg
+
+table = I.styledTag "table" :: I.StyledTag
+table_ = I.styledTag_ "table" :: I.StyledTag_ H.OptProps_table
+
+tbody = I.styledTag "tbody" :: I.StyledTag
+tbody_ = I.styledTag_ "tbody" :: I.StyledTag_ H.OptProps_tbody
+
+td = I.styledTag "td" :: I.StyledTag
+td_ = I.styledTag_ "td" :: I.StyledTag_ H.OptProps_td
+
+template = I.styledTag "template" :: I.StyledTag
+template_ = I.styledTag_ "template" :: I.StyledTag_ H.OptProps_template
+
+textarea = I.styledTag "textarea" :: I.StyledTag
+textarea_ = I.styledTag_ "textarea" :: I.StyledTag_ H.OptProps_textarea
+
+tfoot = I.styledTag "tfoot" :: I.StyledTag
+tfoot_ = I.styledTag_ "tfoot" :: I.StyledTag_ H.OptProps_tfoot
+
+th = I.styledTag "th" :: I.StyledTag
+th_ = I.styledTag_ "th" :: I.StyledTag_ H.OptProps_th
+
+thead = I.styledTag "thead" :: I.StyledTag
+thead_ = I.styledTag_ "thead" :: I.StyledTag_ H.OptProps_thead
+
+time = I.styledTag "time" :: I.StyledTag
+time_ = I.styledTag_ "time" :: I.StyledTag_ H.OptProps_time
+
+title = I.styledTag "title" :: I.StyledTag
+title_ = I.styledTag_ "title" :: I.StyledTag_ H.OptProps_title
+
+tr = I.styledTag "tr" :: I.StyledTag
+tr_ = I.styledTag_ "tr" :: I.StyledTag_ H.OptProps_tr
+
+track = I.styledTagNoContent "track" :: I.StyledTagNoContent
+track_ = I.styledTagNoContent_ "track" :: I.StyledTagNoContent_ H.OptProps_track
+
+u = I.styledTag "u" :: I.StyledTag
+u_ = I.styledTag_ "u" :: I.StyledTag_ H.OptProps_u
+
+ul = I.styledTag "ul" :: I.StyledTag
+ul_ = I.styledTag_ "ul" :: I.StyledTag_ H.OptProps_ul
+
+var = I.styledTag "var" :: I.StyledTag
+var_ = I.styledTag_ "var" :: I.StyledTag_ H.OptProps_var
+
+video = I.styledTag "video" :: I.StyledTag
+video_ = I.styledTag_ "video" :: I.StyledTag_ H.OptProps_video
+
+wbr = I.styledTagNoContent "wbr" :: I.StyledTagNoContent
+wbr_ = I.styledTagNoContent_ "wbr" :: I.StyledTagNoContent_ H.OptProps_wbr


### PR DESCRIPTION
So it seems that the StyledTags experiment was a success, so I made this effort to add it to the library.

1. `index.js` copied to `html.js`, which generates the `HTML.Generated` module - prop types and vanilla tag imports.
1. A sibling script added - `styled.js`, - which generates the `HTML.Styled.Generated` module - same tags, but with `className` promoted
1. `index.js` itself now only does the actual file writing.
1. Underlying mechanics added to the `.Internal` module
1. While I was at it, I also added the CSS support, [as dicussed](https://github.com/collegevine/app/pull/1868#discussion_r384787913)