### PR TITLE
Bump acorn to 6.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react"
   ],
   "devDependencies": {
+    "acorn": "6.4.1",
     "bower": "^1.8.8",
     "lodash": "^4.17.13",
     "pulp": "^13.0.0",


### PR DESCRIPTION
This is a better version of #11: it bumps `acorn` to 6.4.1 because, apparently, a security hole has been discovered, but unlike #11, this PR does it via `package.json`, not `package-lock.json`, which we overwrite every time anyway.