### PR TITLE
Fix some typos in comments

### DIFF
--- a/src/Elmish/HTML/Internal.purs
+++ b/src/Elmish/HTML/Internal.purs
@@ -15,7 +15,7 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | The type of `style` props in React elements. Construct values of this type
 -- | via the `css` function. For example:
 -- |
--- |    div { style: css { height: "50px", width: "50px" } }
+-- |     div { style: css { height: "50px", width: "50px" } }
 -- |
 foreign import data CSS :: Type
 instance jsCSS :: CanPassToJavaScript CSS
@@ -24,7 +24,7 @@ instance jsCSS :: CanPassToJavaScript CSS
 -- | Construct a value of type `CSS`, which is the type of `style` props, out of
 -- | a record. For example:
 -- |
--- |    div { style: css { height: "50px", width: "50px" } }
+-- |     div { style: css { height: "50px", width: "50px" } }
 -- |
 -- | There is currently no type safety regarding the specific fields admitted in
 -- | the style, or different types of those fields. This has been deemed "good
@@ -37,11 +37,11 @@ css = unsafeCoerce
 -- | convenience to construct dictionaries for use as value of the special
 -- | `_data` prop. For example:
 -- |
--- |    div_ "row" { _data: _data { "test-id": "foo", toggle: "autosize" } }
+-- |     div_ "row" { _data: _data { "test-id": "foo", toggle: "autosize" } }
 -- |
 -- | This will correspond to the following HTML:
 -- |
--- |    <div class="row" data-test-id: "foo" data-toggle: "autosize">
+-- |     <div class="row" data-test-id: "foo" data-toggle: "autosize">
 -- |
 _data :: forall r. Homogeneous r String => { | r } -> F.Object String
 _data = F.fromHomogeneous

--- a/src/Elmish/HTML/Styled.purs
+++ b/src/Elmish/HTML/Styled.purs
@@ -19,13 +19,13 @@
 -- | Each tag comes in two flavors: without any props besides the class, and
 -- | with other props. The former is named after the element (e.g. `div`), and
 -- | the latter has an extra underscore at the end (e.g. `div_`). This is done
--- | because, in practice, most elements don't have any props besides `div`, so
--- | it makes the code that much less noisy. For example:
+-- | because, in practice, most elements don't have any props besides
+-- | `className`, so it makes the code that much less noisy. For example:
 -- |
 -- |     div_ "row" { onClick: click } $
 -- |       div "col pl-5 border-right" $
 -- |         [ img_ "img-fluid" { src: "/logo.png" }
--- |         , DOM.text "Hellow Elmish!"
+-- |         , DOM.text "Hello Elmish!"
 -- |         ]
 -- |
 module Elmish.HTML.Styled


### PR DESCRIPTION
After publishing 0.2.0 [on Pursuit](https://pursuit.purescript.org/packages/purescript-elmish-html/0.2.0/docs/Elmish.HTML.Styled) I noticed some typos in the comments.