### PR TITLE
Don't use Elmish standard FFI mechanism for tags

### DIFF
--- a/codegen/html.js
+++ b/codegen/html.js
@@ -14,9 +14,8 @@ module Elmish.HTML.Generated where
 import Prelude
 
 import Effect (Effect)
-import Elmish (EffectFn1, ReactElement, createElement, createElement')
-import Elmish.HTML.Internal (CSS, unsafeCreateDOMComponent)
-import Elmish.React.Import (EmptyProps, ImportedReactComponentConstructor, ImportedReactComponentConstructorWithContent)
+import Elmish (EffectFn1, ReactElement)
+import Elmish.HTML.Internal (CSS, Tag, TagNoContent, tag, tagNoContent)
 import Foreign (Foreign)
 import Foreign.Object (Object)
 import Web.HTML as WH
@@ -41,9 +40,8 @@ const printRow = (e, elProps) =>
     ? `
   ( _data :: Object String
   , ${elProps.map(p => `${p} :: ${propType(e, p)}`).join("\n  , ")}
-  | r
   )`
-    : "( | r )"
+    : "()"
 
 const domTypes = () =>
   props.elements.html
@@ -51,21 +49,15 @@ const domTypes = () =>
       const hasChildren = !voids.includes(e)
       const symbol = reserved.includes(e) ? `${e}'` : e
       return `
-    type OptProps_${e} r =${printRow(
+    type Props_${e} =${printRow(
         e,
         [].concat(props[e] || [], props["*"] || []).sort()
       )}
 
     ${
       hasChildren
-        ? `
-    ${symbol} :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_${e}
-    ${symbol} = createElement $ unsafeCreateDOMComponent "${e}"
-    `
-        : `
-    ${symbol} :: ImportedReactComponentConstructor EmptyProps OptProps_${e}
-    ${symbol} = createElement' $ unsafeCreateDOMComponent "${e}"
-    `
+        ? `${symbol} = tag "${e}" :: Tag Props_${e}`
+        : `${symbol} = tagNoContent "${e}" :: TagNoContent Props_${e}`
     }
 `
     })

--- a/codegen/styled.js
+++ b/codegen/styled.js
@@ -24,7 +24,7 @@ const content = () =>
       const symbol = reserved.includes(e) ? `${e}'` : e
       return `
     ${symbol} = I.styledTag${noContent} "${e}" :: I.StyledTag${noContent}
-    ${symbol}_ = I.styledTag${noContent}_ "${e}" :: I.StyledTag${noContent}_ H.OptProps_${e}
+    ${symbol}_ = I.styledTag${noContent}_ "${e}" :: I.StyledTag${noContent}_ H.Props_${e}
     `
     })
     .map(x => x.replace(/^\n\ {4}/, "").replace(/\n\ {4}/g, "\n"))

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,55 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true
+    },
+    "@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "dev": true,
+      "requires": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -44,6 +93,36 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
     },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -63,9 +142,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true
     },
     "ansi-styles": {
@@ -108,9 +187,9 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -553,6 +632,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -781,6 +866,23 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -791,6 +893,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "deps-sort": {
@@ -909,6 +1017,16 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -922,6 +1040,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true
+    },
+    "err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "dev": true
     },
     "es6-promise": {
@@ -1207,6 +1331,23 @@
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1224,6 +1365,35 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -1240,6 +1410,18 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
       "dev": true
     },
     "inflight": {
@@ -1299,6 +1481,12 @@
         }
       }
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -1311,6 +1499,12 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1318,9 +1512,9 @@
       "dev": true
     },
     "is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
     "is-typedarray": {
@@ -1354,9 +1548,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1393,14 +1587,14 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -1455,6 +1649,145 @@
         "yallist": "^3.0.2"
       }
     },
+    "make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "dev": true,
+      "requires": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "15.3.0",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+          "dev": true,
+          "requires": {
+            "@npmcli/fs": "^1.0.0",
+            "@npmcli/move-file": "^1.0.1",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "glob": "^7.1.4",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^6.0.0",
+            "minipass": "^3.1.1",
+            "minipass-collect": "^1.0.2",
+            "minipass-flush": "^1.0.5",
+            "minipass-pipeline": "^1.2.2",
+            "mkdirp": "^1.0.3",
+            "p-map": "^4.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^8.0.1",
+            "tar": "^6.0.2",
+            "unique-filename": "^1.1.1"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ssri": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+          "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.1.1"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -1489,18 +1822,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.46.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.29",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
-      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.46.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -1544,6 +1877,149 @@
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.12",
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "requires": {
+        "minipass": "^3.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "minizlib": {
@@ -1685,6 +2161,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true
+    },
     "node-static": {
       "version": "0.7.11",
       "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.11.tgz",
@@ -1770,6 +2252,15 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
       "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
       "dev": true
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
     },
     "pako": {
       "version": "1.0.10",
@@ -1878,6 +2369,16 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "requires": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -1960,9 +2461,9 @@
       "dev": true
     },
     "purescript": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.0.tgz",
-      "integrity": "sha512-iTA1k8mwxHqrJp/K296g6omVfve5RCjnB5D6Up93PVtZdP66mCIqlOYC4hrLBHg2hgkk27xePDt5NUXKvH4ApQ==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.9.tgz",
+      "integrity": "sha512-r0J2JX/QuKYBSj8LDDYKQAY+tz/RtIm9erHrqWV7Y8RpUc6TZu14AxWcnSrohbBcEXImY/o0pMpouZrUeyriKQ==",
       "dev": true,
       "requires": {
         "purescript-installer": "^0.2.0"
@@ -2003,9 +2504,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
       "dev": true
     },
     "querystring": {
@@ -2147,6 +2648,12 @@
         }
       }
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -2199,6 +2706,32 @@
         "rimraf": "^2.5.2"
       }
     },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "sha.js": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -2247,9 +2780,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "simple-concat": {
@@ -2257,6 +2790,33 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "dev": true
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
+      }
     },
     "sorcery": {
       "version": "0.10.0",
@@ -2283,19 +2843,81 @@
       "dev": true
     },
     "spago": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/spago/-/spago-0.19.1.tgz",
-      "integrity": "sha512-OD/yopJZ9Ub+XsFtayDeLAWLT4kLdMxosJEyyp8W5OkyJVVSbCrvYacsO7iq3lSuHJmmNny/TEZdyb7uSyupng==",
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/spago/-/spago-0.20.7.tgz",
+      "integrity": "sha512-STsS2FovSMefU00ctkqlqCv5SJ7faopa9n6Utnxq/QNlaAXpXu1YNdAQT+4J5triCUa53Ul/QWfVzwofoTzRfQ==",
       "dev": true,
       "requires": {
-        "request": "^2.88.0",
-        "tar": "^4.4.8"
+        "make-fetch-happen": "^9.1.0",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+          "dev": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+          "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+          "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+          "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+          "dev": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -2455,18 +3077,18 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
           "dev": true
         },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         },
         "safe-buffer": {
@@ -2717,9 +3339,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "elliptic": "^6.5.4",
     "lodash": "^4.17.21",
     "pulp": "^13.0.0",
-    "purescript": "^0.14.0",
+    "purescript": "^0.14.5",
     "purescript-psa": "^0.8.2",
-    "spago": "^0.19.1"
+    "spago": "^0.20.3"
   },
   "license": "MIT"
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -2,31 +2,5 @@ let upstream =
       https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.5-20220102/src/packages.dhall sha256:17ca27f650e91813019dd8c21595b3057d6f4986118d22205bdc7d6ed1ca28e8
 
 in  upstream
-  with elmish.version = "opt"
-  with elmish.dependencies =
-      [ "aff"
-      , "argonaut-core"
-      , "arrays"
-      , "bifunctors"
-      , "console"
-      , "debug"
-      , "effect"
-      , "either"
-      , "foldable-traversable"
-      , "foreign"
-      , "foreign-object"
-      , "functions"
-      , "integers"
-      , "js-date"
-      , "maybe"
-      , "nullable"
-      , "partial"
-      , "prelude"
-      , "refs"
-      , "strings"
-      , "typelevel-prelude"
-      , "undefined-is-not-a-problem"
-      , "unsafe-coerce"
-      , "web-dom"
-      , "web-html"
-      ]
+  with elmish.version = "v0.7.0"
+  with elmish.dependencies = upstream.elmish.dependencies #  ["undefined-is-not-a-problem"]

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,32 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.0-20210313/src/packages.dhall sha256:ba6368b31902aad206851fec930e89465440ebf5a1fe0391f8be396e2d2f1d87
+      https://raw.githubusercontent.com/purescript/package-sets/psc-0.14.5-20220102/src/packages.dhall sha256:17ca27f650e91813019dd8c21595b3057d6f4986118d22205bdc7d6ed1ca28e8
 
 in  upstream
-  with elmish.version = "v0.5.1"
-  with debug.version = "v5.0.0"
+  with elmish.version = "opt"
+  with elmish.dependencies =
+      [ "aff"
+      , "argonaut-core"
+      , "arrays"
+      , "bifunctors"
+      , "console"
+      , "debug"
+      , "effect"
+      , "either"
+      , "foldable-traversable"
+      , "foreign"
+      , "foreign-object"
+      , "functions"
+      , "integers"
+      , "js-date"
+      , "maybe"
+      , "nullable"
+      , "partial"
+      , "prelude"
+      , "refs"
+      , "strings"
+      , "typelevel-prelude"
+      , "undefined-is-not-a-problem"
+      , "unsafe-coerce"
+      , "web-dom"
+      , "web-html"
+      ]

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,7 +1,14 @@
 { name = "elmish-html"
 , dependencies =
-    [ "elmish"
+    [ "effect"
+    , "elmish"
     , "foreign-object"
+    , "foreign"
+    , "prelude"
+    , "record"
+    , "typelevel-prelude"
+    , "unsafe-coerce"
+    , "web-html"
     ]
 , license = "MIT"
 , packages = ./packages.dhall

--- a/src/Elmish/HTML/Generated.purs
+++ b/src/Elmish/HTML/Generated.purs
@@ -7,15 +7,14 @@ module Elmish.HTML.Generated where
 import Prelude
 
 import Effect (Effect)
-import Elmish (EffectFn1, ReactElement, createElement, createElement')
-import Elmish.HTML.Internal (CSS, unsafeCreateDOMComponent)
-import Elmish.React.Import (EmptyProps, ImportedReactComponentConstructor, ImportedReactComponentConstructorWithContent)
+import Elmish (EffectFn1, ReactElement)
+import Elmish.HTML.Internal (CSS, Tag, TagNoContent, tag, tagNoContent)
 import Foreign (Foreign)
 import Foreign.Object (Object)
 import Web.HTML as WH
 
 
-type OptProps_a r =
+type Props_a =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -118,15 +117,11 @@ type OptProps_a r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+a = tag "a" :: Tag Props_a
 
-a :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_a
-a = createElement $ unsafeCreateDOMComponent "a"
-
-
-type OptProps_abbr r =
+type Props_abbr =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -222,15 +217,11 @@ type OptProps_abbr r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+abbr = tag "abbr" :: Tag Props_abbr
 
-abbr :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_abbr
-abbr = createElement $ unsafeCreateDOMComponent "abbr"
-
-
-type OptProps_address r =
+type Props_address =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -325,15 +316,11 @@ type OptProps_address r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+address = tag "address" :: Tag Props_address
 
-address :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_address
-address = createElement $ unsafeCreateDOMComponent "address"
-
-
-type OptProps_area r =
+type Props_area =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -436,15 +423,11 @@ type OptProps_area r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+area = tagNoContent "area" :: TagNoContent Props_area
 
-area :: ImportedReactComponentConstructor EmptyProps OptProps_area
-area = createElement' $ unsafeCreateDOMComponent "area"
-
-
-type OptProps_article r =
+type Props_article =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -539,15 +522,11 @@ type OptProps_article r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+article = tag "article" :: Tag Props_article
 
-article :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_article
-article = createElement $ unsafeCreateDOMComponent "article"
-
-
-type OptProps_aside r =
+type Props_aside =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -642,15 +621,11 @@ type OptProps_aside r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+aside = tag "aside" :: Tag Props_aside
 
-aside :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_aside
-aside = createElement $ unsafeCreateDOMComponent "aside"
-
-
-type OptProps_audio r =
+type Props_audio =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -750,15 +725,11 @@ type OptProps_audio r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+audio = tag "audio" :: Tag Props_audio
 
-audio :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_audio
-audio = createElement $ unsafeCreateDOMComponent "audio"
-
-
-type OptProps_b r =
+type Props_b =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -853,15 +824,11 @@ type OptProps_b r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+b = tag "b" :: Tag Props_b
 
-b :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_b
-b = createElement $ unsafeCreateDOMComponent "b"
-
-
-type OptProps_base r =
+type Props_base =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -958,15 +925,11 @@ type OptProps_base r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+base = tagNoContent "base" :: TagNoContent Props_base
 
-base :: ImportedReactComponentConstructor EmptyProps OptProps_base
-base = createElement' $ unsafeCreateDOMComponent "base"
-
-
-type OptProps_bdi r =
+type Props_bdi =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1061,15 +1024,11 @@ type OptProps_bdi r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+bdi = tag "bdi" :: Tag Props_bdi
 
-bdi :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_bdi
-bdi = createElement $ unsafeCreateDOMComponent "bdi"
-
-
-type OptProps_bdo r =
+type Props_bdo =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1165,15 +1124,11 @@ type OptProps_bdo r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+bdo = tag "bdo" :: Tag Props_bdo
 
-bdo :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_bdo
-bdo = createElement $ unsafeCreateDOMComponent "bdo"
-
-
-type OptProps_blockquote r =
+type Props_blockquote =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1269,15 +1224,11 @@ type OptProps_blockquote r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+blockquote = tag "blockquote" :: Tag Props_blockquote
 
-blockquote :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_blockquote
-blockquote = createElement $ unsafeCreateDOMComponent "blockquote"
-
-
-type OptProps_body r =
+type Props_body =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1372,15 +1323,11 @@ type OptProps_body r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+body = tag "body" :: Tag Props_body
 
-body :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_body
-body = createElement $ unsafeCreateDOMComponent "body"
-
-
-type OptProps_br r =
+type Props_br =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1475,15 +1422,11 @@ type OptProps_br r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+br = tagNoContent "br" :: TagNoContent Props_br
 
-br :: ImportedReactComponentConstructor EmptyProps OptProps_br
-br = createElement' $ unsafeCreateDOMComponent "br"
-
-
-type OptProps_button r =
+type Props_button =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1583,15 +1526,11 @@ type OptProps_button r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+button = tag "button" :: Tag Props_button
 
-button :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_button
-button = createElement $ unsafeCreateDOMComponent "button"
-
-
-type OptProps_canvas r =
+type Props_canvas =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1688,15 +1627,11 @@ type OptProps_canvas r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+canvas = tag "canvas" :: Tag Props_canvas
 
-canvas :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_canvas
-canvas = createElement $ unsafeCreateDOMComponent "canvas"
-
-
-type OptProps_caption r =
+type Props_caption =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1791,15 +1726,11 @@ type OptProps_caption r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+caption = tag "caption" :: Tag Props_caption
 
-caption :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_caption
-caption = createElement $ unsafeCreateDOMComponent "caption"
-
-
-type OptProps_cite r =
+type Props_cite =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1894,15 +1825,11 @@ type OptProps_cite r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+cite = tag "cite" :: Tag Props_cite
 
-cite :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_cite
-cite = createElement $ unsafeCreateDOMComponent "cite"
-
-
-type OptProps_code r =
+type Props_code =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -1997,120 +1924,11 @@ type OptProps_code r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+code = tag "code" :: Tag Props_code
 
-code :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_code
-code = createElement $ unsafeCreateDOMComponent "code"
-
-
-type OptProps_col r =
-  ( _data :: Object String
-  , about :: String
-  , acceptCharset :: String
-  , accessKey :: String
-  , allowFullScreen :: Boolean
-  , allowTransparency :: Boolean
-  , autoComplete :: Boolean
-  , autoFocus :: Boolean
-  , autoPlay :: Boolean
-  , capture :: Boolean
-  , cellPadding :: String
-  , cellSpacing :: String
-  , charSet :: String
-  , classID :: String
-  , className :: String
-  , colSpan :: Int
-  , contentEditable :: Boolean
-  , contextMenu :: String
-  , crossOrigin :: String
-  , dangerouslySetInnerHTML :: { __html :: String }
-  , datatype :: String
-  , dateTime :: String
-  , dir :: String
-  , draggable :: Boolean
-  , encType :: String
-  , formAction :: String
-  , formEncType :: String
-  , formMethod :: String
-  , formNoValidate :: Boolean
-  , formTarget :: String
-  , frameBorder :: String
-  , hidden :: Boolean
-  , hrefLang :: String
-  , htmlFor :: String
-  , httpEquiv :: String
-  , icon :: String
-  , id :: String
-  , inlist :: String
-  , inputMode :: String
-  , is :: String
-  , itemID :: String
-  , itemProp :: String
-  , itemRef :: String
-  , itemScope :: Boolean
-  , itemType :: String
-  , key :: String
-  , keyParams :: String
-  , keyType :: String
-  , lang :: String
-  , marginHeight :: String
-  , marginWidth :: String
-  , maxLength :: Int
-  , mediaGroup :: String
-  , minLength :: Int
-  , noValidate :: Boolean
-  , onBlur :: Effect Unit
-  , onClick :: Effect Unit
-  , onDoubleClick :: Effect Unit
-  , onFocus :: Effect Unit
-  , onKeyDown :: EffectFn1 Foreign Unit
-  , onKeyPress :: EffectFn1 Foreign Unit
-  , onKeyUp :: EffectFn1 Foreign Unit
-  , onMouseDown :: EffectFn1 Foreign Unit
-  , onMouseEnter :: EffectFn1 Foreign Unit
-  , onMouseLeave :: EffectFn1 Foreign Unit
-  , onMouseMove :: EffectFn1 Foreign Unit
-  , onMouseOut :: EffectFn1 Foreign Unit
-  , onMouseOver :: EffectFn1 Foreign Unit
-  , onMouseUp :: EffectFn1 Foreign Unit
-  , onScroll :: EffectFn1 Foreign Unit
-  , prefix :: String
-  , property :: String
-  , radioGroup :: String
-  , readOnly :: Boolean
-  , ref :: EffectFn1 WH.HTMLElement Unit
-  , resource :: String
-  , role :: String
-  , rowSpan :: Int
-  , scoped :: Boolean
-  , seamless :: Boolean
-  , security :: String
-  , span :: Int
-  , spellCheck :: Boolean
-  , srcDoc :: ReactElement
-  , srcLang :: String
-  , srcSet :: String
-  , style :: CSS
-  , suppressContentEditableWarning :: Boolean
-  , tabIndex :: Int
-  , title :: String
-  , typeof :: String
-  , unselectable :: Boolean
-  , useMap :: String
-  , vocab :: String
-  , width :: String
-  , wmode :: String
-  | r
-  )
-
-
-col :: ImportedReactComponentConstructor EmptyProps OptProps_col
-col = createElement' $ unsafeCreateDOMComponent "col"
-
-
-type OptProps_colgroup r =
+type Props_col =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2207,15 +2025,112 @@ type OptProps_colgroup r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+col = tagNoContent "col" :: TagNoContent Props_col
 
-colgroup :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_colgroup
-colgroup = createElement $ unsafeCreateDOMComponent "colgroup"
+type Props_colgroup =
+  ( _data :: Object String
+  , about :: String
+  , acceptCharset :: String
+  , accessKey :: String
+  , allowFullScreen :: Boolean
+  , allowTransparency :: Boolean
+  , autoComplete :: Boolean
+  , autoFocus :: Boolean
+  , autoPlay :: Boolean
+  , capture :: Boolean
+  , cellPadding :: String
+  , cellSpacing :: String
+  , charSet :: String
+  , classID :: String
+  , className :: String
+  , colSpan :: Int
+  , contentEditable :: Boolean
+  , contextMenu :: String
+  , crossOrigin :: String
+  , dangerouslySetInnerHTML :: { __html :: String }
+  , datatype :: String
+  , dateTime :: String
+  , dir :: String
+  , draggable :: Boolean
+  , encType :: String
+  , formAction :: String
+  , formEncType :: String
+  , formMethod :: String
+  , formNoValidate :: Boolean
+  , formTarget :: String
+  , frameBorder :: String
+  , hidden :: Boolean
+  , hrefLang :: String
+  , htmlFor :: String
+  , httpEquiv :: String
+  , icon :: String
+  , id :: String
+  , inlist :: String
+  , inputMode :: String
+  , is :: String
+  , itemID :: String
+  , itemProp :: String
+  , itemRef :: String
+  , itemScope :: Boolean
+  , itemType :: String
+  , key :: String
+  , keyParams :: String
+  , keyType :: String
+  , lang :: String
+  , marginHeight :: String
+  , marginWidth :: String
+  , maxLength :: Int
+  , mediaGroup :: String
+  , minLength :: Int
+  , noValidate :: Boolean
+  , onBlur :: Effect Unit
+  , onClick :: Effect Unit
+  , onDoubleClick :: Effect Unit
+  , onFocus :: Effect Unit
+  , onKeyDown :: EffectFn1 Foreign Unit
+  , onKeyPress :: EffectFn1 Foreign Unit
+  , onKeyUp :: EffectFn1 Foreign Unit
+  , onMouseDown :: EffectFn1 Foreign Unit
+  , onMouseEnter :: EffectFn1 Foreign Unit
+  , onMouseLeave :: EffectFn1 Foreign Unit
+  , onMouseMove :: EffectFn1 Foreign Unit
+  , onMouseOut :: EffectFn1 Foreign Unit
+  , onMouseOver :: EffectFn1 Foreign Unit
+  , onMouseUp :: EffectFn1 Foreign Unit
+  , onScroll :: EffectFn1 Foreign Unit
+  , prefix :: String
+  , property :: String
+  , radioGroup :: String
+  , readOnly :: Boolean
+  , ref :: EffectFn1 WH.HTMLElement Unit
+  , resource :: String
+  , role :: String
+  , rowSpan :: Int
+  , scoped :: Boolean
+  , seamless :: Boolean
+  , security :: String
+  , span :: Int
+  , spellCheck :: Boolean
+  , srcDoc :: ReactElement
+  , srcLang :: String
+  , srcSet :: String
+  , style :: CSS
+  , suppressContentEditableWarning :: Boolean
+  , tabIndex :: Int
+  , title :: String
+  , typeof :: String
+  , unselectable :: Boolean
+  , useMap :: String
+  , vocab :: String
+  , width :: String
+  , wmode :: String
+  )
 
+colgroup = tag "colgroup" :: Tag Props_colgroup
 
-type OptProps_data r =
+type Props_data =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2311,15 +2226,11 @@ type OptProps_data r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+data' = tag "data" :: Tag Props_data
 
-data' :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_data
-data' = createElement $ unsafeCreateDOMComponent "data"
-
-
-type OptProps_datalist r =
+type Props_datalist =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2414,15 +2325,11 @@ type OptProps_datalist r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+datalist = tag "datalist" :: Tag Props_datalist
 
-datalist :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_datalist
-datalist = createElement $ unsafeCreateDOMComponent "datalist"
-
-
-type OptProps_dd r =
+type Props_dd =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2517,15 +2424,11 @@ type OptProps_dd r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+dd = tag "dd" :: Tag Props_dd
 
-dd :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_dd
-dd = createElement $ unsafeCreateDOMComponent "dd"
-
-
-type OptProps_del r =
+type Props_del =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2621,15 +2524,11 @@ type OptProps_del r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+del = tag "del" :: Tag Props_del
 
-del :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_del
-del = createElement $ unsafeCreateDOMComponent "del"
-
-
-type OptProps_details r =
+type Props_details =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2725,15 +2624,11 @@ type OptProps_details r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+details = tag "details" :: Tag Props_details
 
-details :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_details
-details = createElement $ unsafeCreateDOMComponent "details"
-
-
-type OptProps_dfn r =
+type Props_dfn =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2829,15 +2724,11 @@ type OptProps_dfn r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+dfn = tag "dfn" :: Tag Props_dfn
 
-dfn :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_dfn
-dfn = createElement $ unsafeCreateDOMComponent "dfn"
-
-
-type OptProps_dialog r =
+type Props_dialog =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -2933,15 +2824,11 @@ type OptProps_dialog r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+dialog = tag "dialog" :: Tag Props_dialog
 
-dialog :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_dialog
-dialog = createElement $ unsafeCreateDOMComponent "dialog"
-
-
-type OptProps_div r =
+type Props_div =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3036,15 +2923,11 @@ type OptProps_div r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+div = tag "div" :: Tag Props_div
 
-div :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_div
-div = createElement $ unsafeCreateDOMComponent "div"
-
-
-type OptProps_dl r =
+type Props_dl =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3139,15 +3022,11 @@ type OptProps_dl r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+dl = tag "dl" :: Tag Props_dl
 
-dl :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_dl
-dl = createElement $ unsafeCreateDOMComponent "dl"
-
-
-type OptProps_dt r =
+type Props_dt =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3242,15 +3121,11 @@ type OptProps_dt r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+dt = tag "dt" :: Tag Props_dt
 
-dt :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_dt
-dt = createElement $ unsafeCreateDOMComponent "dt"
-
-
-type OptProps_em r =
+type Props_em =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3345,15 +3220,11 @@ type OptProps_em r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+em = tag "em" :: Tag Props_em
 
-em :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_em
-em = createElement $ unsafeCreateDOMComponent "em"
-
-
-type OptProps_embed r =
+type Props_embed =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3452,15 +3323,11 @@ type OptProps_embed r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+embed = tagNoContent "embed" :: TagNoContent Props_embed
 
-embed :: ImportedReactComponentConstructor EmptyProps OptProps_embed
-embed = createElement' $ unsafeCreateDOMComponent "embed"
-
-
-type OptProps_fieldset r =
+type Props_fieldset =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3558,15 +3425,11 @@ type OptProps_fieldset r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+fieldset = tag "fieldset" :: Tag Props_fieldset
 
-fieldset :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_fieldset
-fieldset = createElement $ unsafeCreateDOMComponent "fieldset"
-
-
-type OptProps_figcaption r =
+type Props_figcaption =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3661,15 +3524,11 @@ type OptProps_figcaption r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+figcaption = tag "figcaption" :: Tag Props_figcaption
 
-figcaption :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_figcaption
-figcaption = createElement $ unsafeCreateDOMComponent "figcaption"
-
-
-type OptProps_figure r =
+type Props_figure =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3764,15 +3623,11 @@ type OptProps_figure r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+figure = tag "figure" :: Tag Props_figure
 
-figure :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_figure
-figure = createElement $ unsafeCreateDOMComponent "figure"
-
-
-type OptProps_footer r =
+type Props_footer =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -3867,15 +3722,11 @@ type OptProps_footer r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+footer = tag "footer" :: Tag Props_footer
 
-footer :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_footer
-footer = createElement $ unsafeCreateDOMComponent "footer"
-
-
-type OptProps_form r =
+type Props_form =
   ( _data :: Object String
   , about :: String
   , accept :: String
@@ -3979,15 +3830,11 @@ type OptProps_form r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+form = tag "form" :: Tag Props_form
 
-form :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_form
-form = createElement $ unsafeCreateDOMComponent "form"
-
-
-type OptProps_h1 r =
+type Props_h1 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4082,15 +3929,11 @@ type OptProps_h1 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h1 = tag "h1" :: Tag Props_h1
 
-h1 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h1
-h1 = createElement $ unsafeCreateDOMComponent "h1"
-
-
-type OptProps_h2 r =
+type Props_h2 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4185,15 +4028,11 @@ type OptProps_h2 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h2 = tag "h2" :: Tag Props_h2
 
-h2 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h2
-h2 = createElement $ unsafeCreateDOMComponent "h2"
-
-
-type OptProps_h3 r =
+type Props_h3 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4288,15 +4127,11 @@ type OptProps_h3 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h3 = tag "h3" :: Tag Props_h3
 
-h3 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h3
-h3 = createElement $ unsafeCreateDOMComponent "h3"
-
-
-type OptProps_h4 r =
+type Props_h4 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4391,15 +4226,11 @@ type OptProps_h4 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h4 = tag "h4" :: Tag Props_h4
 
-h4 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h4
-h4 = createElement $ unsafeCreateDOMComponent "h4"
-
-
-type OptProps_h5 r =
+type Props_h5 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4494,15 +4325,11 @@ type OptProps_h5 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h5 = tag "h5" :: Tag Props_h5
 
-h5 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h5
-h5 = createElement $ unsafeCreateDOMComponent "h5"
-
-
-type OptProps_h6 r =
+type Props_h6 =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4597,15 +4424,11 @@ type OptProps_h6 r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+h6 = tag "h6" :: Tag Props_h6
 
-h6 :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_h6
-h6 = createElement $ unsafeCreateDOMComponent "h6"
-
-
-type OptProps_head r =
+type Props_head =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4701,15 +4524,11 @@ type OptProps_head r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+head = tag "head" :: Tag Props_head
 
-head :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_head
-head = createElement $ unsafeCreateDOMComponent "head"
-
-
-type OptProps_header r =
+type Props_header =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4804,15 +4623,11 @@ type OptProps_header r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+header = tag "header" :: Tag Props_header
 
-header :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_header
-header = createElement $ unsafeCreateDOMComponent "header"
-
-
-type OptProps_hgroup r =
+type Props_hgroup =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -4907,15 +4722,11 @@ type OptProps_hgroup r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+hgroup = tag "hgroup" :: Tag Props_hgroup
 
-hgroup :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_hgroup
-hgroup = createElement $ unsafeCreateDOMComponent "hgroup"
-
-
-type OptProps_hr r =
+type Props_hr =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5012,15 +4823,11 @@ type OptProps_hr r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+hr = tagNoContent "hr" :: TagNoContent Props_hr
 
-hr :: ImportedReactComponentConstructor EmptyProps OptProps_hr
-hr = createElement' $ unsafeCreateDOMComponent "hr"
-
-
-type OptProps_html r =
+type Props_html =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5116,15 +4923,11 @@ type OptProps_html r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+html = tag "html" :: Tag Props_html
 
-html :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_html
-html = createElement $ unsafeCreateDOMComponent "html"
-
-
-type OptProps_i r =
+type Props_i =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5219,15 +5022,11 @@ type OptProps_i r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+i = tag "i" :: Tag Props_i
 
-i :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_i
-i = createElement $ unsafeCreateDOMComponent "i"
-
-
-type OptProps_iframe r =
+type Props_iframe =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5328,15 +5127,11 @@ type OptProps_iframe r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+iframe = tag "iframe" :: Tag Props_iframe
 
-iframe :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_iframe
-iframe = createElement $ unsafeCreateDOMComponent "iframe"
-
-
-type OptProps_img r =
+type Props_img =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5438,15 +5233,11 @@ type OptProps_img r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+img = tagNoContent "img" :: TagNoContent Props_img
 
-img :: ImportedReactComponentConstructor EmptyProps OptProps_img
-img = createElement' $ unsafeCreateDOMComponent "img"
-
-
-type OptProps_input r =
+type Props_input =
   ( _data :: Object String
   , about :: String
   , accept :: String
@@ -5569,15 +5360,11 @@ type OptProps_input r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+input = tagNoContent "input" :: TagNoContent Props_input
 
-input :: ImportedReactComponentConstructor EmptyProps OptProps_input
-input = createElement' $ unsafeCreateDOMComponent "input"
-
-
-type OptProps_ins r =
+type Props_ins =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5673,15 +5460,11 @@ type OptProps_ins r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+ins = tag "ins" :: Tag Props_ins
 
-ins :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_ins
-ins = createElement $ unsafeCreateDOMComponent "ins"
-
-
-type OptProps_kbd r =
+type Props_kbd =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5776,15 +5559,11 @@ type OptProps_kbd r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+kbd = tag "kbd" :: Tag Props_kbd
 
-kbd :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_kbd
-kbd = createElement $ unsafeCreateDOMComponent "kbd"
-
-
-type OptProps_keygen r =
+type Props_keygen =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5883,15 +5662,11 @@ type OptProps_keygen r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+keygen = tag "keygen" :: Tag Props_keygen
 
-keygen :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_keygen
-keygen = createElement $ unsafeCreateDOMComponent "keygen"
-
-
-type OptProps_label r =
+type Props_label =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -5987,15 +5762,11 @@ type OptProps_label r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+label = tag "label" :: Tag Props_label
 
-label :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_label
-label = createElement $ unsafeCreateDOMComponent "label"
-
-
-type OptProps_legend r =
+type Props_legend =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6090,15 +5861,11 @@ type OptProps_legend r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+legend = tag "legend" :: Tag Props_legend
 
-legend :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_legend
-legend = createElement $ unsafeCreateDOMComponent "legend"
-
-
-type OptProps_li r =
+type Props_li =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6195,15 +5962,11 @@ type OptProps_li r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+li = tag "li" :: Tag Props_li
 
-li :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_li
-li = createElement $ unsafeCreateDOMComponent "li"
-
-
-type OptProps_link r =
+type Props_link =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6309,15 +6072,11 @@ type OptProps_link r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+link = tagNoContent "link" :: TagNoContent Props_link
 
-link :: ImportedReactComponentConstructor EmptyProps OptProps_link
-link = createElement' $ unsafeCreateDOMComponent "link"
-
-
-type OptProps_main r =
+type Props_main =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6412,15 +6171,11 @@ type OptProps_main r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+main = tag "main" :: Tag Props_main
 
-main :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_main
-main = createElement $ unsafeCreateDOMComponent "main"
-
-
-type OptProps_map r =
+type Props_map =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6516,15 +6271,11 @@ type OptProps_map r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+map = tag "map" :: Tag Props_map
 
-map :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_map
-map = createElement $ unsafeCreateDOMComponent "map"
-
-
-type OptProps_mark r =
+type Props_mark =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6619,15 +6370,11 @@ type OptProps_mark r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+mark = tag "mark" :: Tag Props_mark
 
-mark :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_mark
-mark = createElement $ unsafeCreateDOMComponent "mark"
-
-
-type OptProps_math r =
+type Props_math =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6722,15 +6469,11 @@ type OptProps_math r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+math = tag "math" :: Tag Props_math
 
-math :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_math
-math = createElement $ unsafeCreateDOMComponent "math"
-
-
-type OptProps_menu r =
+type Props_menu =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6825,15 +6568,11 @@ type OptProps_menu r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+menu = tag "menu" :: Tag Props_menu
 
-menu :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_menu
-menu = createElement $ unsafeCreateDOMComponent "menu"
-
-
-type OptProps_menuitem r =
+type Props_menuitem =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -6928,15 +6667,11 @@ type OptProps_menuitem r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+menuitem = tag "menuitem" :: Tag Props_menuitem
 
-menuitem :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_menuitem
-menuitem = createElement $ unsafeCreateDOMComponent "menuitem"
-
-
-type OptProps_meta r =
+type Props_meta =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7033,15 +6768,11 @@ type OptProps_meta r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+meta = tagNoContent "meta" :: TagNoContent Props_meta
 
-meta :: ImportedReactComponentConstructor EmptyProps OptProps_meta
-meta = createElement' $ unsafeCreateDOMComponent "meta"
-
-
-type OptProps_meter r =
+type Props_meter =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7142,15 +6873,11 @@ type OptProps_meter r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+meter = tag "meter" :: Tag Props_meter
 
-meter :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_meter
-meter = createElement $ unsafeCreateDOMComponent "meter"
-
-
-type OptProps_nav r =
+type Props_nav =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7245,15 +6972,11 @@ type OptProps_nav r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+nav = tag "nav" :: Tag Props_nav
 
-nav :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_nav
-nav = createElement $ unsafeCreateDOMComponent "nav"
-
-
-type OptProps_noscript r =
+type Props_noscript =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7348,15 +7071,11 @@ type OptProps_noscript r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+noscript = tag "noscript" :: Tag Props_noscript
 
-noscript :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_noscript
-noscript = createElement $ unsafeCreateDOMComponent "noscript"
-
-
-type OptProps_object r =
+type Props_object =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7457,15 +7176,11 @@ type OptProps_object r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+object = tag "object" :: Tag Props_object
 
-object :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_object
-object = createElement $ unsafeCreateDOMComponent "object"
-
-
-type OptProps_ol r =
+type Props_ol =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7563,15 +7278,11 @@ type OptProps_ol r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+ol = tag "ol" :: Tag Props_ol
 
-ol :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_ol
-ol = createElement $ unsafeCreateDOMComponent "ol"
-
-
-type OptProps_optgroup r =
+type Props_optgroup =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7668,15 +7379,11 @@ type OptProps_optgroup r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+optgroup = tag "optgroup" :: Tag Props_optgroup
 
-optgroup :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_optgroup
-optgroup = createElement $ unsafeCreateDOMComponent "optgroup"
-
-
-type OptProps_option r =
+type Props_option =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7775,15 +7482,11 @@ type OptProps_option r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+option = tag "option" :: Tag Props_option
 
-option :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_option
-option = createElement $ unsafeCreateDOMComponent "option"
-
-
-type OptProps_output r =
+type Props_output =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7880,15 +7583,11 @@ type OptProps_output r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+output = tag "output" :: Tag Props_output
 
-output :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_output
-output = createElement $ unsafeCreateDOMComponent "output"
-
-
-type OptProps_p r =
+type Props_p =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -7983,15 +7682,11 @@ type OptProps_p r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+p = tag "p" :: Tag Props_p
 
-p :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_p
-p = createElement $ unsafeCreateDOMComponent "p"
-
-
-type OptProps_param r =
+type Props_param =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8089,15 +7784,11 @@ type OptProps_param r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+param = tagNoContent "param" :: TagNoContent Props_param
 
-param :: ImportedReactComponentConstructor EmptyProps OptProps_param
-param = createElement' $ unsafeCreateDOMComponent "param"
-
-
-type OptProps_picture r =
+type Props_picture =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8192,15 +7883,11 @@ type OptProps_picture r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+picture = tag "picture" :: Tag Props_picture
 
-picture :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_picture
-picture = createElement $ unsafeCreateDOMComponent "picture"
-
-
-type OptProps_pre r =
+type Props_pre =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8296,15 +7983,11 @@ type OptProps_pre r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+pre = tag "pre" :: Tag Props_pre
 
-pre :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_pre
-pre = createElement $ unsafeCreateDOMComponent "pre"
-
-
-type OptProps_progress r =
+type Props_progress =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8401,15 +8084,11 @@ type OptProps_progress r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+progress = tag "progress" :: Tag Props_progress
 
-progress :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_progress
-progress = createElement $ unsafeCreateDOMComponent "progress"
-
-
-type OptProps_q r =
+type Props_q =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8505,15 +8184,11 @@ type OptProps_q r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+q = tag "q" :: Tag Props_q
 
-q :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_q
-q = createElement $ unsafeCreateDOMComponent "q"
-
-
-type OptProps_rb r =
+type Props_rb =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8608,15 +8283,11 @@ type OptProps_rb r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+rb = tag "rb" :: Tag Props_rb
 
-rb :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_rb
-rb = createElement $ unsafeCreateDOMComponent "rb"
-
-
-type OptProps_rp r =
+type Props_rp =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8711,15 +8382,11 @@ type OptProps_rp r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+rp = tag "rp" :: Tag Props_rp
 
-rp :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_rp
-rp = createElement $ unsafeCreateDOMComponent "rp"
-
-
-type OptProps_rt r =
+type Props_rt =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8814,15 +8481,11 @@ type OptProps_rt r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+rt = tag "rt" :: Tag Props_rt
 
-rt :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_rt
-rt = createElement $ unsafeCreateDOMComponent "rt"
-
-
-type OptProps_rtc r =
+type Props_rtc =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -8917,15 +8580,11 @@ type OptProps_rtc r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+rtc = tag "rtc" :: Tag Props_rtc
 
-rtc :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_rtc
-rtc = createElement $ unsafeCreateDOMComponent "rtc"
-
-
-type OptProps_ruby r =
+type Props_ruby =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9020,15 +8679,11 @@ type OptProps_ruby r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+ruby = tag "ruby" :: Tag Props_ruby
 
-ruby :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_ruby
-ruby = createElement $ unsafeCreateDOMComponent "ruby"
-
-
-type OptProps_s r =
+type Props_s =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9123,15 +8778,11 @@ type OptProps_s r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+s = tag "s" :: Tag Props_s
 
-s :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_s
-s = createElement $ unsafeCreateDOMComponent "s"
-
-
-type OptProps_samp r =
+type Props_samp =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9226,15 +8877,11 @@ type OptProps_samp r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+samp = tag "samp" :: Tag Props_samp
 
-samp :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_samp
-samp = createElement $ unsafeCreateDOMComponent "samp"
-
-
-type OptProps_script r =
+type Props_script =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9335,15 +8982,11 @@ type OptProps_script r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+script = tag "script" :: Tag Props_script
 
-script :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_script
-script = createElement $ unsafeCreateDOMComponent "script"
-
-
-type OptProps_section r =
+type Props_section =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9438,15 +9081,11 @@ type OptProps_section r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+section = tag "section" :: Tag Props_section
 
-section :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_section
-section = createElement $ unsafeCreateDOMComponent "section"
-
-
-type OptProps_select r =
+type Props_select =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9550,15 +9189,11 @@ type OptProps_select r =
   , value :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+select = tag "select" :: Tag Props_select
 
-select :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_select
-select = createElement $ unsafeCreateDOMComponent "select"
-
-
-type OptProps_slot r =
+type Props_slot =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9654,15 +9289,11 @@ type OptProps_slot r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+slot = tag "slot" :: Tag Props_slot
 
-slot :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_slot
-slot = createElement $ unsafeCreateDOMComponent "slot"
-
-
-type OptProps_small r =
+type Props_small =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9757,15 +9388,11 @@ type OptProps_small r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+small = tag "small" :: Tag Props_small
 
-small :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_small
-small = createElement $ unsafeCreateDOMComponent "small"
-
-
-type OptProps_source r =
+type Props_source =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9864,15 +9491,11 @@ type OptProps_source r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+source = tagNoContent "source" :: TagNoContent Props_source
 
-source :: ImportedReactComponentConstructor EmptyProps OptProps_source
-source = createElement' $ unsafeCreateDOMComponent "source"
-
-
-type OptProps_span r =
+type Props_span =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -9967,15 +9590,11 @@ type OptProps_span r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+span = tag "span" :: Tag Props_span
 
-span :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_span
-span = createElement $ unsafeCreateDOMComponent "span"
-
-
-type OptProps_strong r =
+type Props_strong =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10070,15 +9689,11 @@ type OptProps_strong r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+strong = tag "strong" :: Tag Props_strong
 
-strong :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_strong
-strong = createElement $ unsafeCreateDOMComponent "strong"
-
-
-type OptProps_style r =
+type Props_style =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10177,15 +9792,11 @@ type OptProps_style r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+style = tag "style" :: Tag Props_style
 
-style :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_style
-style = createElement $ unsafeCreateDOMComponent "style"
-
-
-type OptProps_sub r =
+type Props_sub =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10280,15 +9891,11 @@ type OptProps_sub r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+sub = tag "sub" :: Tag Props_sub
 
-sub :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_sub
-sub = createElement $ unsafeCreateDOMComponent "sub"
-
-
-type OptProps_summary r =
+type Props_summary =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10383,15 +9990,11 @@ type OptProps_summary r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+summary = tag "summary" :: Tag Props_summary
 
-summary :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_summary
-summary = createElement $ unsafeCreateDOMComponent "summary"
-
-
-type OptProps_sup r =
+type Props_sup =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10486,15 +10089,11 @@ type OptProps_sup r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+sup = tag "sup" :: Tag Props_sup
 
-sup :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_sup
-sup = createElement $ unsafeCreateDOMComponent "sup"
-
-
-type OptProps_svg r =
+type Props_svg =
   ( _data :: Object String
   , about :: String
   , accentHeight :: String
@@ -10831,15 +10430,11 @@ type OptProps_svg r =
   , yChannelSelector :: String
   , z :: String
   , zoomAndPan :: String
-  | r
   )
 
+svg = tag "svg" :: Tag Props_svg
 
-svg :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_svg
-svg = createElement $ unsafeCreateDOMComponent "svg"
-
-
-type OptProps_table r =
+type Props_table =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -10936,15 +10531,11 @@ type OptProps_table r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+table = tag "table" :: Tag Props_table
 
-table :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_table
-table = createElement $ unsafeCreateDOMComponent "table"
-
-
-type OptProps_tbody r =
+type Props_tbody =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11039,15 +10630,11 @@ type OptProps_tbody r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+tbody = tag "tbody" :: Tag Props_tbody
 
-tbody :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_tbody
-tbody = createElement $ unsafeCreateDOMComponent "tbody"
-
-
-type OptProps_td r =
+type Props_td =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11146,15 +10733,11 @@ type OptProps_td r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+td = tag "td" :: Tag Props_td
 
-td :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_td
-td = createElement $ unsafeCreateDOMComponent "td"
-
-
-type OptProps_template r =
+type Props_template =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11249,15 +10832,11 @@ type OptProps_template r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+template = tag "template" :: Tag Props_template
 
-template :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_template
-template = createElement $ unsafeCreateDOMComponent "template"
-
-
-type OptProps_textarea r =
+type Props_textarea =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11365,15 +10944,11 @@ type OptProps_textarea r =
   , vocab :: String
   , wmode :: String
   , wrap :: String
-  | r
   )
 
+textarea = tagNoContent "textarea" :: TagNoContent Props_textarea
 
-textarea :: ImportedReactComponentConstructor EmptyProps OptProps_textarea
-textarea = createElement' $ unsafeCreateDOMComponent "textarea"
-
-
-type OptProps_tfoot r =
+type Props_tfoot =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11468,15 +11043,11 @@ type OptProps_tfoot r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+tfoot = tag "tfoot" :: Tag Props_tfoot
 
-tfoot :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_tfoot
-tfoot = createElement $ unsafeCreateDOMComponent "tfoot"
-
-
-type OptProps_th r =
+type Props_th =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11575,15 +11146,11 @@ type OptProps_th r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+th = tag "th" :: Tag Props_th
 
-th :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_th
-th = createElement $ unsafeCreateDOMComponent "th"
-
-
-type OptProps_thead r =
+type Props_thead =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11678,15 +11245,11 @@ type OptProps_thead r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+thead = tag "thead" :: Tag Props_thead
 
-thead :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_thead
-thead = createElement $ unsafeCreateDOMComponent "thead"
-
-
-type OptProps_time r =
+type Props_time =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11781,15 +11344,11 @@ type OptProps_time r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+time = tag "time" :: Tag Props_time
 
-time :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_time
-time = createElement $ unsafeCreateDOMComponent "time"
-
-
-type OptProps_title r =
+type Props_title =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11884,15 +11443,11 @@ type OptProps_title r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+title = tag "title" :: Tag Props_title
 
-title :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_title
-title = createElement $ unsafeCreateDOMComponent "title"
-
-
-type OptProps_tr r =
+type Props_tr =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -11987,15 +11542,11 @@ type OptProps_tr r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+tr = tag "tr" :: Tag Props_tr
 
-tr :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_tr
-tr = createElement $ unsafeCreateDOMComponent "tr"
-
-
-type OptProps_track r =
+type Props_track =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12094,15 +11645,11 @@ type OptProps_track r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+track = tagNoContent "track" :: TagNoContent Props_track
 
-track :: ImportedReactComponentConstructor EmptyProps OptProps_track
-track = createElement' $ unsafeCreateDOMComponent "track"
-
-
-type OptProps_u r =
+type Props_u =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12197,15 +11744,11 @@ type OptProps_u r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+u = tag "u" :: Tag Props_u
 
-u :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_u
-u = createElement $ unsafeCreateDOMComponent "u"
-
-
-type OptProps_ul r =
+type Props_ul =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12301,15 +11844,11 @@ type OptProps_ul r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+ul = tag "ul" :: Tag Props_ul
 
-ul :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_ul
-ul = createElement $ unsafeCreateDOMComponent "ul"
-
-
-type OptProps_var r =
+type Props_var =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12404,15 +11943,11 @@ type OptProps_var r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
+var = tag "var" :: Tag Props_var
 
-var :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_var
-var = createElement $ unsafeCreateDOMComponent "var"
-
-
-type OptProps_video r =
+type Props_video =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12521,15 +12056,11 @@ type OptProps_video r =
   , vocab :: String
   , width :: String
   , wmode :: String
-  | r
   )
 
+video = tag "video" :: Tag Props_video
 
-video :: ImportedReactComponentConstructorWithContent EmptyProps OptProps_video
-video = createElement $ unsafeCreateDOMComponent "video"
-
-
-type OptProps_wbr r =
+type Props_wbr =
   ( _data :: Object String
   , about :: String
   , acceptCharset :: String
@@ -12624,10 +12155,6 @@ type OptProps_wbr r =
   , useMap :: String
   , vocab :: String
   , wmode :: String
-  | r
   )
 
-
-wbr :: ImportedReactComponentConstructor EmptyProps OptProps_wbr
-wbr = createElement' $ unsafeCreateDOMComponent "wbr"
-
+wbr = tagNoContent "wbr" :: TagNoContent Props_wbr

--- a/src/Elmish/HTML/Styled/Generated.purs
+++ b/src/Elmish/HTML/Styled/Generated.purs
@@ -9,355 +9,355 @@ import Elmish.HTML.Internal as I
 
 
 a = I.styledTag "a" :: I.StyledTag
-a_ = I.styledTag_ "a" :: I.StyledTag_ H.OptProps_a
+a_ = I.styledTag_ "a" :: I.StyledTag_ H.Props_a
 
 abbr = I.styledTag "abbr" :: I.StyledTag
-abbr_ = I.styledTag_ "abbr" :: I.StyledTag_ H.OptProps_abbr
+abbr_ = I.styledTag_ "abbr" :: I.StyledTag_ H.Props_abbr
 
 address = I.styledTag "address" :: I.StyledTag
-address_ = I.styledTag_ "address" :: I.StyledTag_ H.OptProps_address
+address_ = I.styledTag_ "address" :: I.StyledTag_ H.Props_address
 
 area = I.styledTagNoContent "area" :: I.StyledTagNoContent
-area_ = I.styledTagNoContent_ "area" :: I.StyledTagNoContent_ H.OptProps_area
+area_ = I.styledTagNoContent_ "area" :: I.StyledTagNoContent_ H.Props_area
 
 article = I.styledTag "article" :: I.StyledTag
-article_ = I.styledTag_ "article" :: I.StyledTag_ H.OptProps_article
+article_ = I.styledTag_ "article" :: I.StyledTag_ H.Props_article
 
 aside = I.styledTag "aside" :: I.StyledTag
-aside_ = I.styledTag_ "aside" :: I.StyledTag_ H.OptProps_aside
+aside_ = I.styledTag_ "aside" :: I.StyledTag_ H.Props_aside
 
 audio = I.styledTag "audio" :: I.StyledTag
-audio_ = I.styledTag_ "audio" :: I.StyledTag_ H.OptProps_audio
+audio_ = I.styledTag_ "audio" :: I.StyledTag_ H.Props_audio
 
 b = I.styledTag "b" :: I.StyledTag
-b_ = I.styledTag_ "b" :: I.StyledTag_ H.OptProps_b
+b_ = I.styledTag_ "b" :: I.StyledTag_ H.Props_b
 
 base = I.styledTagNoContent "base" :: I.StyledTagNoContent
-base_ = I.styledTagNoContent_ "base" :: I.StyledTagNoContent_ H.OptProps_base
+base_ = I.styledTagNoContent_ "base" :: I.StyledTagNoContent_ H.Props_base
 
 bdi = I.styledTag "bdi" :: I.StyledTag
-bdi_ = I.styledTag_ "bdi" :: I.StyledTag_ H.OptProps_bdi
+bdi_ = I.styledTag_ "bdi" :: I.StyledTag_ H.Props_bdi
 
 bdo = I.styledTag "bdo" :: I.StyledTag
-bdo_ = I.styledTag_ "bdo" :: I.StyledTag_ H.OptProps_bdo
+bdo_ = I.styledTag_ "bdo" :: I.StyledTag_ H.Props_bdo
 
 blockquote = I.styledTag "blockquote" :: I.StyledTag
-blockquote_ = I.styledTag_ "blockquote" :: I.StyledTag_ H.OptProps_blockquote
+blockquote_ = I.styledTag_ "blockquote" :: I.StyledTag_ H.Props_blockquote
 
 body = I.styledTag "body" :: I.StyledTag
-body_ = I.styledTag_ "body" :: I.StyledTag_ H.OptProps_body
+body_ = I.styledTag_ "body" :: I.StyledTag_ H.Props_body
 
 br = I.styledTagNoContent "br" :: I.StyledTagNoContent
-br_ = I.styledTagNoContent_ "br" :: I.StyledTagNoContent_ H.OptProps_br
+br_ = I.styledTagNoContent_ "br" :: I.StyledTagNoContent_ H.Props_br
 
 button = I.styledTag "button" :: I.StyledTag
-button_ = I.styledTag_ "button" :: I.StyledTag_ H.OptProps_button
+button_ = I.styledTag_ "button" :: I.StyledTag_ H.Props_button
 
 canvas = I.styledTag "canvas" :: I.StyledTag
-canvas_ = I.styledTag_ "canvas" :: I.StyledTag_ H.OptProps_canvas
+canvas_ = I.styledTag_ "canvas" :: I.StyledTag_ H.Props_canvas
 
 caption = I.styledTag "caption" :: I.StyledTag
-caption_ = I.styledTag_ "caption" :: I.StyledTag_ H.OptProps_caption
+caption_ = I.styledTag_ "caption" :: I.StyledTag_ H.Props_caption
 
 cite = I.styledTag "cite" :: I.StyledTag
-cite_ = I.styledTag_ "cite" :: I.StyledTag_ H.OptProps_cite
+cite_ = I.styledTag_ "cite" :: I.StyledTag_ H.Props_cite
 
 code = I.styledTag "code" :: I.StyledTag
-code_ = I.styledTag_ "code" :: I.StyledTag_ H.OptProps_code
+code_ = I.styledTag_ "code" :: I.StyledTag_ H.Props_code
 
 col = I.styledTagNoContent "col" :: I.StyledTagNoContent
-col_ = I.styledTagNoContent_ "col" :: I.StyledTagNoContent_ H.OptProps_col
+col_ = I.styledTagNoContent_ "col" :: I.StyledTagNoContent_ H.Props_col
 
 colgroup = I.styledTag "colgroup" :: I.StyledTag
-colgroup_ = I.styledTag_ "colgroup" :: I.StyledTag_ H.OptProps_colgroup
+colgroup_ = I.styledTag_ "colgroup" :: I.StyledTag_ H.Props_colgroup
 
 data' = I.styledTag "data" :: I.StyledTag
-data'_ = I.styledTag_ "data" :: I.StyledTag_ H.OptProps_data
+data'_ = I.styledTag_ "data" :: I.StyledTag_ H.Props_data
 
 datalist = I.styledTag "datalist" :: I.StyledTag
-datalist_ = I.styledTag_ "datalist" :: I.StyledTag_ H.OptProps_datalist
+datalist_ = I.styledTag_ "datalist" :: I.StyledTag_ H.Props_datalist
 
 dd = I.styledTag "dd" :: I.StyledTag
-dd_ = I.styledTag_ "dd" :: I.StyledTag_ H.OptProps_dd
+dd_ = I.styledTag_ "dd" :: I.StyledTag_ H.Props_dd
 
 del = I.styledTag "del" :: I.StyledTag
-del_ = I.styledTag_ "del" :: I.StyledTag_ H.OptProps_del
+del_ = I.styledTag_ "del" :: I.StyledTag_ H.Props_del
 
 details = I.styledTag "details" :: I.StyledTag
-details_ = I.styledTag_ "details" :: I.StyledTag_ H.OptProps_details
+details_ = I.styledTag_ "details" :: I.StyledTag_ H.Props_details
 
 dfn = I.styledTag "dfn" :: I.StyledTag
-dfn_ = I.styledTag_ "dfn" :: I.StyledTag_ H.OptProps_dfn
+dfn_ = I.styledTag_ "dfn" :: I.StyledTag_ H.Props_dfn
 
 dialog = I.styledTag "dialog" :: I.StyledTag
-dialog_ = I.styledTag_ "dialog" :: I.StyledTag_ H.OptProps_dialog
+dialog_ = I.styledTag_ "dialog" :: I.StyledTag_ H.Props_dialog
 
 div = I.styledTag "div" :: I.StyledTag
-div_ = I.styledTag_ "div" :: I.StyledTag_ H.OptProps_div
+div_ = I.styledTag_ "div" :: I.StyledTag_ H.Props_div
 
 dl = I.styledTag "dl" :: I.StyledTag
-dl_ = I.styledTag_ "dl" :: I.StyledTag_ H.OptProps_dl
+dl_ = I.styledTag_ "dl" :: I.StyledTag_ H.Props_dl
 
 dt = I.styledTag "dt" :: I.StyledTag
-dt_ = I.styledTag_ "dt" :: I.StyledTag_ H.OptProps_dt
+dt_ = I.styledTag_ "dt" :: I.StyledTag_ H.Props_dt
 
 em = I.styledTag "em" :: I.StyledTag
-em_ = I.styledTag_ "em" :: I.StyledTag_ H.OptProps_em
+em_ = I.styledTag_ "em" :: I.StyledTag_ H.Props_em
 
 embed = I.styledTagNoContent "embed" :: I.StyledTagNoContent
-embed_ = I.styledTagNoContent_ "embed" :: I.StyledTagNoContent_ H.OptProps_embed
+embed_ = I.styledTagNoContent_ "embed" :: I.StyledTagNoContent_ H.Props_embed
 
 fieldset = I.styledTag "fieldset" :: I.StyledTag
-fieldset_ = I.styledTag_ "fieldset" :: I.StyledTag_ H.OptProps_fieldset
+fieldset_ = I.styledTag_ "fieldset" :: I.StyledTag_ H.Props_fieldset
 
 figcaption = I.styledTag "figcaption" :: I.StyledTag
-figcaption_ = I.styledTag_ "figcaption" :: I.StyledTag_ H.OptProps_figcaption
+figcaption_ = I.styledTag_ "figcaption" :: I.StyledTag_ H.Props_figcaption
 
 figure = I.styledTag "figure" :: I.StyledTag
-figure_ = I.styledTag_ "figure" :: I.StyledTag_ H.OptProps_figure
+figure_ = I.styledTag_ "figure" :: I.StyledTag_ H.Props_figure
 
 footer = I.styledTag "footer" :: I.StyledTag
-footer_ = I.styledTag_ "footer" :: I.StyledTag_ H.OptProps_footer
+footer_ = I.styledTag_ "footer" :: I.StyledTag_ H.Props_footer
 
 form = I.styledTag "form" :: I.StyledTag
-form_ = I.styledTag_ "form" :: I.StyledTag_ H.OptProps_form
+form_ = I.styledTag_ "form" :: I.StyledTag_ H.Props_form
 
 h1 = I.styledTag "h1" :: I.StyledTag
-h1_ = I.styledTag_ "h1" :: I.StyledTag_ H.OptProps_h1
+h1_ = I.styledTag_ "h1" :: I.StyledTag_ H.Props_h1
 
 h2 = I.styledTag "h2" :: I.StyledTag
-h2_ = I.styledTag_ "h2" :: I.StyledTag_ H.OptProps_h2
+h2_ = I.styledTag_ "h2" :: I.StyledTag_ H.Props_h2
 
 h3 = I.styledTag "h3" :: I.StyledTag
-h3_ = I.styledTag_ "h3" :: I.StyledTag_ H.OptProps_h3
+h3_ = I.styledTag_ "h3" :: I.StyledTag_ H.Props_h3
 
 h4 = I.styledTag "h4" :: I.StyledTag
-h4_ = I.styledTag_ "h4" :: I.StyledTag_ H.OptProps_h4
+h4_ = I.styledTag_ "h4" :: I.StyledTag_ H.Props_h4
 
 h5 = I.styledTag "h5" :: I.StyledTag
-h5_ = I.styledTag_ "h5" :: I.StyledTag_ H.OptProps_h5
+h5_ = I.styledTag_ "h5" :: I.StyledTag_ H.Props_h5
 
 h6 = I.styledTag "h6" :: I.StyledTag
-h6_ = I.styledTag_ "h6" :: I.StyledTag_ H.OptProps_h6
+h6_ = I.styledTag_ "h6" :: I.StyledTag_ H.Props_h6
 
 head = I.styledTag "head" :: I.StyledTag
-head_ = I.styledTag_ "head" :: I.StyledTag_ H.OptProps_head
+head_ = I.styledTag_ "head" :: I.StyledTag_ H.Props_head
 
 header = I.styledTag "header" :: I.StyledTag
-header_ = I.styledTag_ "header" :: I.StyledTag_ H.OptProps_header
+header_ = I.styledTag_ "header" :: I.StyledTag_ H.Props_header
 
 hgroup = I.styledTag "hgroup" :: I.StyledTag
-hgroup_ = I.styledTag_ "hgroup" :: I.StyledTag_ H.OptProps_hgroup
+hgroup_ = I.styledTag_ "hgroup" :: I.StyledTag_ H.Props_hgroup
 
 hr = I.styledTagNoContent "hr" :: I.StyledTagNoContent
-hr_ = I.styledTagNoContent_ "hr" :: I.StyledTagNoContent_ H.OptProps_hr
+hr_ = I.styledTagNoContent_ "hr" :: I.StyledTagNoContent_ H.Props_hr
 
 html = I.styledTag "html" :: I.StyledTag
-html_ = I.styledTag_ "html" :: I.StyledTag_ H.OptProps_html
+html_ = I.styledTag_ "html" :: I.StyledTag_ H.Props_html
 
 i = I.styledTag "i" :: I.StyledTag
-i_ = I.styledTag_ "i" :: I.StyledTag_ H.OptProps_i
+i_ = I.styledTag_ "i" :: I.StyledTag_ H.Props_i
 
 iframe = I.styledTag "iframe" :: I.StyledTag
-iframe_ = I.styledTag_ "iframe" :: I.StyledTag_ H.OptProps_iframe
+iframe_ = I.styledTag_ "iframe" :: I.StyledTag_ H.Props_iframe
 
 img = I.styledTagNoContent "img" :: I.StyledTagNoContent
-img_ = I.styledTagNoContent_ "img" :: I.StyledTagNoContent_ H.OptProps_img
+img_ = I.styledTagNoContent_ "img" :: I.StyledTagNoContent_ H.Props_img
 
 input = I.styledTagNoContent "input" :: I.StyledTagNoContent
-input_ = I.styledTagNoContent_ "input" :: I.StyledTagNoContent_ H.OptProps_input
+input_ = I.styledTagNoContent_ "input" :: I.StyledTagNoContent_ H.Props_input
 
 ins = I.styledTag "ins" :: I.StyledTag
-ins_ = I.styledTag_ "ins" :: I.StyledTag_ H.OptProps_ins
+ins_ = I.styledTag_ "ins" :: I.StyledTag_ H.Props_ins
 
 kbd = I.styledTag "kbd" :: I.StyledTag
-kbd_ = I.styledTag_ "kbd" :: I.StyledTag_ H.OptProps_kbd
+kbd_ = I.styledTag_ "kbd" :: I.StyledTag_ H.Props_kbd
 
 keygen = I.styledTag "keygen" :: I.StyledTag
-keygen_ = I.styledTag_ "keygen" :: I.StyledTag_ H.OptProps_keygen
+keygen_ = I.styledTag_ "keygen" :: I.StyledTag_ H.Props_keygen
 
 label = I.styledTag "label" :: I.StyledTag
-label_ = I.styledTag_ "label" :: I.StyledTag_ H.OptProps_label
+label_ = I.styledTag_ "label" :: I.StyledTag_ H.Props_label
 
 legend = I.styledTag "legend" :: I.StyledTag
-legend_ = I.styledTag_ "legend" :: I.StyledTag_ H.OptProps_legend
+legend_ = I.styledTag_ "legend" :: I.StyledTag_ H.Props_legend
 
 li = I.styledTag "li" :: I.StyledTag
-li_ = I.styledTag_ "li" :: I.StyledTag_ H.OptProps_li
+li_ = I.styledTag_ "li" :: I.StyledTag_ H.Props_li
 
 link = I.styledTagNoContent "link" :: I.StyledTagNoContent
-link_ = I.styledTagNoContent_ "link" :: I.StyledTagNoContent_ H.OptProps_link
+link_ = I.styledTagNoContent_ "link" :: I.StyledTagNoContent_ H.Props_link
 
 main = I.styledTag "main" :: I.StyledTag
-main_ = I.styledTag_ "main" :: I.StyledTag_ H.OptProps_main
+main_ = I.styledTag_ "main" :: I.StyledTag_ H.Props_main
 
 map = I.styledTag "map" :: I.StyledTag
-map_ = I.styledTag_ "map" :: I.StyledTag_ H.OptProps_map
+map_ = I.styledTag_ "map" :: I.StyledTag_ H.Props_map
 
 mark = I.styledTag "mark" :: I.StyledTag
-mark_ = I.styledTag_ "mark" :: I.StyledTag_ H.OptProps_mark
+mark_ = I.styledTag_ "mark" :: I.StyledTag_ H.Props_mark
 
 math = I.styledTag "math" :: I.StyledTag
-math_ = I.styledTag_ "math" :: I.StyledTag_ H.OptProps_math
+math_ = I.styledTag_ "math" :: I.StyledTag_ H.Props_math
 
 menu = I.styledTag "menu" :: I.StyledTag
-menu_ = I.styledTag_ "menu" :: I.StyledTag_ H.OptProps_menu
+menu_ = I.styledTag_ "menu" :: I.StyledTag_ H.Props_menu
 
 menuitem = I.styledTag "menuitem" :: I.StyledTag
-menuitem_ = I.styledTag_ "menuitem" :: I.StyledTag_ H.OptProps_menuitem
+menuitem_ = I.styledTag_ "menuitem" :: I.StyledTag_ H.Props_menuitem
 
 meta = I.styledTagNoContent "meta" :: I.StyledTagNoContent
-meta_ = I.styledTagNoContent_ "meta" :: I.StyledTagNoContent_ H.OptProps_meta
+meta_ = I.styledTagNoContent_ "meta" :: I.StyledTagNoContent_ H.Props_meta
 
 meter = I.styledTag "meter" :: I.StyledTag
-meter_ = I.styledTag_ "meter" :: I.StyledTag_ H.OptProps_meter
+meter_ = I.styledTag_ "meter" :: I.StyledTag_ H.Props_meter
 
 nav = I.styledTag "nav" :: I.StyledTag
-nav_ = I.styledTag_ "nav" :: I.StyledTag_ H.OptProps_nav
+nav_ = I.styledTag_ "nav" :: I.StyledTag_ H.Props_nav
 
 noscript = I.styledTag "noscript" :: I.StyledTag
-noscript_ = I.styledTag_ "noscript" :: I.StyledTag_ H.OptProps_noscript
+noscript_ = I.styledTag_ "noscript" :: I.StyledTag_ H.Props_noscript
 
 object = I.styledTag "object" :: I.StyledTag
-object_ = I.styledTag_ "object" :: I.StyledTag_ H.OptProps_object
+object_ = I.styledTag_ "object" :: I.StyledTag_ H.Props_object
 
 ol = I.styledTag "ol" :: I.StyledTag
-ol_ = I.styledTag_ "ol" :: I.StyledTag_ H.OptProps_ol
+ol_ = I.styledTag_ "ol" :: I.StyledTag_ H.Props_ol
 
 optgroup = I.styledTag "optgroup" :: I.StyledTag
-optgroup_ = I.styledTag_ "optgroup" :: I.StyledTag_ H.OptProps_optgroup
+optgroup_ = I.styledTag_ "optgroup" :: I.StyledTag_ H.Props_optgroup
 
 option = I.styledTag "option" :: I.StyledTag
-option_ = I.styledTag_ "option" :: I.StyledTag_ H.OptProps_option
+option_ = I.styledTag_ "option" :: I.StyledTag_ H.Props_option
 
 output = I.styledTag "output" :: I.StyledTag
-output_ = I.styledTag_ "output" :: I.StyledTag_ H.OptProps_output
+output_ = I.styledTag_ "output" :: I.StyledTag_ H.Props_output
 
 p = I.styledTag "p" :: I.StyledTag
-p_ = I.styledTag_ "p" :: I.StyledTag_ H.OptProps_p
+p_ = I.styledTag_ "p" :: I.StyledTag_ H.Props_p
 
 param = I.styledTagNoContent "param" :: I.StyledTagNoContent
-param_ = I.styledTagNoContent_ "param" :: I.StyledTagNoContent_ H.OptProps_param
+param_ = I.styledTagNoContent_ "param" :: I.StyledTagNoContent_ H.Props_param
 
 picture = I.styledTag "picture" :: I.StyledTag
-picture_ = I.styledTag_ "picture" :: I.StyledTag_ H.OptProps_picture
+picture_ = I.styledTag_ "picture" :: I.StyledTag_ H.Props_picture
 
 pre = I.styledTag "pre" :: I.StyledTag
-pre_ = I.styledTag_ "pre" :: I.StyledTag_ H.OptProps_pre
+pre_ = I.styledTag_ "pre" :: I.StyledTag_ H.Props_pre
 
 progress = I.styledTag "progress" :: I.StyledTag
-progress_ = I.styledTag_ "progress" :: I.StyledTag_ H.OptProps_progress
+progress_ = I.styledTag_ "progress" :: I.StyledTag_ H.Props_progress
 
 q = I.styledTag "q" :: I.StyledTag
-q_ = I.styledTag_ "q" :: I.StyledTag_ H.OptProps_q
+q_ = I.styledTag_ "q" :: I.StyledTag_ H.Props_q
 
 rb = I.styledTag "rb" :: I.StyledTag
-rb_ = I.styledTag_ "rb" :: I.StyledTag_ H.OptProps_rb
+rb_ = I.styledTag_ "rb" :: I.StyledTag_ H.Props_rb
 
 rp = I.styledTag "rp" :: I.StyledTag
-rp_ = I.styledTag_ "rp" :: I.StyledTag_ H.OptProps_rp
+rp_ = I.styledTag_ "rp" :: I.StyledTag_ H.Props_rp
 
 rt = I.styledTag "rt" :: I.StyledTag
-rt_ = I.styledTag_ "rt" :: I.StyledTag_ H.OptProps_rt
+rt_ = I.styledTag_ "rt" :: I.StyledTag_ H.Props_rt
 
 rtc = I.styledTag "rtc" :: I.StyledTag
-rtc_ = I.styledTag_ "rtc" :: I.StyledTag_ H.OptProps_rtc
+rtc_ = I.styledTag_ "rtc" :: I.StyledTag_ H.Props_rtc
 
 ruby = I.styledTag "ruby" :: I.StyledTag
-ruby_ = I.styledTag_ "ruby" :: I.StyledTag_ H.OptProps_ruby
+ruby_ = I.styledTag_ "ruby" :: I.StyledTag_ H.Props_ruby
 
 s = I.styledTag "s" :: I.StyledTag
-s_ = I.styledTag_ "s" :: I.StyledTag_ H.OptProps_s
+s_ = I.styledTag_ "s" :: I.StyledTag_ H.Props_s
 
 samp = I.styledTag "samp" :: I.StyledTag
-samp_ = I.styledTag_ "samp" :: I.StyledTag_ H.OptProps_samp
+samp_ = I.styledTag_ "samp" :: I.StyledTag_ H.Props_samp
 
 script = I.styledTag "script" :: I.StyledTag
-script_ = I.styledTag_ "script" :: I.StyledTag_ H.OptProps_script
+script_ = I.styledTag_ "script" :: I.StyledTag_ H.Props_script
 
 section = I.styledTag "section" :: I.StyledTag
-section_ = I.styledTag_ "section" :: I.StyledTag_ H.OptProps_section
+section_ = I.styledTag_ "section" :: I.StyledTag_ H.Props_section
 
 select = I.styledTag "select" :: I.StyledTag
-select_ = I.styledTag_ "select" :: I.StyledTag_ H.OptProps_select
+select_ = I.styledTag_ "select" :: I.StyledTag_ H.Props_select
 
 slot = I.styledTag "slot" :: I.StyledTag
-slot_ = I.styledTag_ "slot" :: I.StyledTag_ H.OptProps_slot
+slot_ = I.styledTag_ "slot" :: I.StyledTag_ H.Props_slot
 
 small = I.styledTag "small" :: I.StyledTag
-small_ = I.styledTag_ "small" :: I.StyledTag_ H.OptProps_small
+small_ = I.styledTag_ "small" :: I.StyledTag_ H.Props_small
 
 source = I.styledTagNoContent "source" :: I.StyledTagNoContent
-source_ = I.styledTagNoContent_ "source" :: I.StyledTagNoContent_ H.OptProps_source
+source_ = I.styledTagNoContent_ "source" :: I.StyledTagNoContent_ H.Props_source
 
 span = I.styledTag "span" :: I.StyledTag
-span_ = I.styledTag_ "span" :: I.StyledTag_ H.OptProps_span
+span_ = I.styledTag_ "span" :: I.StyledTag_ H.Props_span
 
 strong = I.styledTag "strong" :: I.StyledTag
-strong_ = I.styledTag_ "strong" :: I.StyledTag_ H.OptProps_strong
+strong_ = I.styledTag_ "strong" :: I.StyledTag_ H.Props_strong
 
 style = I.styledTag "style" :: I.StyledTag
-style_ = I.styledTag_ "style" :: I.StyledTag_ H.OptProps_style
+style_ = I.styledTag_ "style" :: I.StyledTag_ H.Props_style
 
 sub = I.styledTag "sub" :: I.StyledTag
-sub_ = I.styledTag_ "sub" :: I.StyledTag_ H.OptProps_sub
+sub_ = I.styledTag_ "sub" :: I.StyledTag_ H.Props_sub
 
 summary = I.styledTag "summary" :: I.StyledTag
-summary_ = I.styledTag_ "summary" :: I.StyledTag_ H.OptProps_summary
+summary_ = I.styledTag_ "summary" :: I.StyledTag_ H.Props_summary
 
 sup = I.styledTag "sup" :: I.StyledTag
-sup_ = I.styledTag_ "sup" :: I.StyledTag_ H.OptProps_sup
+sup_ = I.styledTag_ "sup" :: I.StyledTag_ H.Props_sup
 
 svg = I.styledTag "svg" :: I.StyledTag
-svg_ = I.styledTag_ "svg" :: I.StyledTag_ H.OptProps_svg
+svg_ = I.styledTag_ "svg" :: I.StyledTag_ H.Props_svg
 
 table = I.styledTag "table" :: I.StyledTag
-table_ = I.styledTag_ "table" :: I.StyledTag_ H.OptProps_table
+table_ = I.styledTag_ "table" :: I.StyledTag_ H.Props_table
 
 tbody = I.styledTag "tbody" :: I.StyledTag
-tbody_ = I.styledTag_ "tbody" :: I.StyledTag_ H.OptProps_tbody
+tbody_ = I.styledTag_ "tbody" :: I.StyledTag_ H.Props_tbody
 
 td = I.styledTag "td" :: I.StyledTag
-td_ = I.styledTag_ "td" :: I.StyledTag_ H.OptProps_td
+td_ = I.styledTag_ "td" :: I.StyledTag_ H.Props_td
 
 template = I.styledTag "template" :: I.StyledTag
-template_ = I.styledTag_ "template" :: I.StyledTag_ H.OptProps_template
+template_ = I.styledTag_ "template" :: I.StyledTag_ H.Props_template
 
 textarea = I.styledTagNoContent "textarea" :: I.StyledTagNoContent
-textarea_ = I.styledTagNoContent_ "textarea" :: I.StyledTagNoContent_ H.OptProps_textarea
+textarea_ = I.styledTagNoContent_ "textarea" :: I.StyledTagNoContent_ H.Props_textarea
 
 tfoot = I.styledTag "tfoot" :: I.StyledTag
-tfoot_ = I.styledTag_ "tfoot" :: I.StyledTag_ H.OptProps_tfoot
+tfoot_ = I.styledTag_ "tfoot" :: I.StyledTag_ H.Props_tfoot
 
 th = I.styledTag "th" :: I.StyledTag
-th_ = I.styledTag_ "th" :: I.StyledTag_ H.OptProps_th
+th_ = I.styledTag_ "th" :: I.StyledTag_ H.Props_th
 
 thead = I.styledTag "thead" :: I.StyledTag
-thead_ = I.styledTag_ "thead" :: I.StyledTag_ H.OptProps_thead
+thead_ = I.styledTag_ "thead" :: I.StyledTag_ H.Props_thead
 
 time = I.styledTag "time" :: I.StyledTag
-time_ = I.styledTag_ "time" :: I.StyledTag_ H.OptProps_time
+time_ = I.styledTag_ "time" :: I.StyledTag_ H.Props_time
 
 title = I.styledTag "title" :: I.StyledTag
-title_ = I.styledTag_ "title" :: I.StyledTag_ H.OptProps_title
+title_ = I.styledTag_ "title" :: I.StyledTag_ H.Props_title
 
 tr = I.styledTag "tr" :: I.StyledTag
-tr_ = I.styledTag_ "tr" :: I.StyledTag_ H.OptProps_tr
+tr_ = I.styledTag_ "tr" :: I.StyledTag_ H.Props_tr
 
 track = I.styledTagNoContent "track" :: I.StyledTagNoContent
-track_ = I.styledTagNoContent_ "track" :: I.StyledTagNoContent_ H.OptProps_track
+track_ = I.styledTagNoContent_ "track" :: I.StyledTagNoContent_ H.Props_track
 
 u = I.styledTag "u" :: I.StyledTag
-u_ = I.styledTag_ "u" :: I.StyledTag_ H.OptProps_u
+u_ = I.styledTag_ "u" :: I.StyledTag_ H.Props_u
 
 ul = I.styledTag "ul" :: I.StyledTag
-ul_ = I.styledTag_ "ul" :: I.StyledTag_ H.OptProps_ul
+ul_ = I.styledTag_ "ul" :: I.StyledTag_ H.Props_ul
 
 var = I.styledTag "var" :: I.StyledTag
-var_ = I.styledTag_ "var" :: I.StyledTag_ H.OptProps_var
+var_ = I.styledTag_ "var" :: I.StyledTag_ H.Props_var
 
 video = I.styledTag "video" :: I.StyledTag
-video_ = I.styledTag_ "video" :: I.StyledTag_ H.OptProps_video
+video_ = I.styledTag_ "video" :: I.StyledTag_ H.Props_video
 
 wbr = I.styledTagNoContent "wbr" :: I.StyledTagNoContent
-wbr_ = I.styledTagNoContent_ "wbr" :: I.StyledTagNoContent_ H.OptProps_wbr
+wbr_ = I.styledTagNoContent_ "wbr" :: I.StyledTagNoContent_ H.Props_wbr


### PR DESCRIPTION
This is a companion PR for https://github.com/collegevine/purescript-elmish/pull/58

* No longer using standard Elmish FFI mechanism for the tags.
* Instead just verifying that the provided props are a subset of the allowed ones (via the `Union` class).
